### PR TITLE
replace usage of deprecated mongo option maxScan with maxTimeMS

### DIFF
--- a/config/env/default.js
+++ b/config/env/default.js
@@ -296,9 +296,9 @@ module.exports = {
 	},
 
 	/*
-	 * The maximum number of records allowed to be scanned by a mongo query
+	 * The maximum time in milliseconds allowed for processing operation on the cursor by a mongo query
 	 */
-	maxScan: 30000,
+	maxTimeMS: 30000,
 
 	/*
 	 * The maximum number of records allowed to be exported to csv

--- a/src/app/common/query.service.js
+++ b/src/app/common/query.service.js
@@ -40,7 +40,7 @@ function pagingQuery(schema, find, projection, options, sort, limit, offset, run
 
 	// Build the query
 	let baseQuery = schema.find(find);
-	let findQuery = schema.find(find, projection, options).sort(sort).skip(offset).limit(limit).maxscan(config.maxScan);
+	let findQuery = schema.find(find, projection, options).sort(sort).skip(offset).limit(limit).maxTimeMS(config.maxTimeMS);
 
 	// Add population
 	if (populate) {

--- a/src/app/core/config/config.controller.js
+++ b/src/app/core/config/config.controller.js
@@ -19,7 +19,6 @@ let getSystemConfig = function() {
 
 		contactEmail: config.contactEmail,
 
-		maxScan: config.maxScan,
 		maxExport: config.maxExport,
 		feedback: config.feedback
 	};


### PR DESCRIPTION
`maxScan` was [removed](https://docs.mongodb.com/manual/release-notes/4.2-compatibility/#remove-maxscan) in mongo 4.2.