### PR TITLE
add app.url and app.clientUrl config to default config

### DIFF
--- a/config/env/default.js
+++ b/config/env/default.js
@@ -115,7 +115,12 @@ module.exports = {
 		title: 'Node REST Starter',
 		name: 'Node Rest Starter',
 		instanceName: 'node-rest-starter',
-		baseUrl: 'http://localhost'
+		url: {
+			protocol: 'http',
+			host: 'localhost',
+			port: 3000
+		},
+		clientUrl: 'http://localhost/#'
 	},
 
 	// Header/footer

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "scripts": {
     "start": "nodemon ./src/server.js --exec 'npm run lint && node --inspect' | bunyan",
-    "start:dev": "export NODE_ENV=development && yarn start",
+    "start:dev": "export NODE_ENV=development && npm run start",
     "test": "NODE_ENV=test nodemon ./src/test.js",
     "test:ci": "NODE_ENV=test nyc --reporter=lcov node ./src/test.js --ci",
     "test:gitlab": "NODE_ENV=testgitlab nyc --reporter=lcov --reporter=text-summary node ./src/test.js --ci",


### PR DESCRIPTION
This is a minor update.  Code relies on these config properties but they are not defined in default config.  `clientUrl` is duplicative `baseUrl`, but more descriptive, so I choose to keep it over `baseUrl`.  Will be submitting a PR for ngx-starter to use `clientUrl` vs `baseUrl`.