### PR TITLE
fix: Ensure accessChecker is always called

### DIFF
--- a/src/lib/strategies/proxy-pki.js
+++ b/src/lib/strategies/proxy-pki.js
@@ -154,8 +154,8 @@ async function handleUser(dn, req, isProxy) {
 
 	let localUser = await User.findOne({ 'providerData.dnLower': dnLower }).exec();
 
-	// Bypass AC check if we are still within the set login time.
-	if (localUser && (localUser.bypassAccessCheck || localUser.lastLogin + config.auth.sessionCookie.maxAge > Date.now())) {
+	// Bypass AC check
+	if (localUser && localUser.bypassAccessCheck) {
 		return localUser;
 	}
 


### PR DESCRIPTION
Previously a check was added to bypass the access checker if the user had logged in within the session life (currently 24 hours).  This prevented the user object from being updated properly when the access checker cache entry was deleted or refreshed.