### PR TITLE
fix(feedback): Require only user be logged in to submit feedback

### DIFF
--- a/src/app/core/feedback/feedback.controller.spec.js
+++ b/src/app/core/feedback/feedback.controller.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const request = require('supertest'),
+const request = require('supertest'), q = require('q'),
 	should = require('should'),
 	express = require('express'),
 	bodyParser = require('body-parser'),
@@ -41,6 +41,12 @@ describe('Feedback Controller', () => {
 
 		// Mock access for the User Controller method that adds authentication to these endpoints
 		mock('../user/user.controller', {
+			has: () => {
+				return (req, res, next) => {
+					req.user = fakeUser;
+					next();
+				};
+			},
 			hasAccess: (req, res, next) => {
 				req.user = fakeUser;
 				next(); // pass-through

--- a/src/app/core/feedback/feedback.routes.js
+++ b/src/app/core/feedback/feedback.routes.js
@@ -67,7 +67,7 @@ const router = express.Router();
  *           message: 'User is not logged in'
  */
 router.route('/feedback')
-	.post(user.hasAccess, feedback.submitFeedback);
+	.post(user.has(user.requiresLogin), feedback.submitFeedback);
 
 router.route('/admin/feedback')
 	.post(user.hasAdminAccess, feedback.search);


### PR DESCRIPTION
Previously, if a user was logged in, but had not been assigned the user role, they would be unable to submit feedback.