### PR TITLE
Correction to inactive email test

### DIFF
--- a/src/app/core/user/inactive/inactive-user-email.service.js
+++ b/src/app/core/user/inactive/inactive-user-email.service.js
@@ -2,6 +2,7 @@
 
 const
 	_ = require('lodash'),
+	moment = require('moment'),
 
 	deps = require('../../../../dependencies'),
 	dbs = deps.dbs,
@@ -12,10 +13,8 @@ const
 
 	User = dbs.admin.model('User');
 
-const day = 86400000;
-
 async function sendEmail(user, emailConfig) {
-	const numOfDays = Math.floor((Date.now() - user.lastLogin)/day);
+	const numOfDays = moment().diff(user.lastLogin, 'days');
 	try {
 		const mailOptions = await emailService.generateMailOptions(user, null, emailConfig, {
 			daysAgo: numOfDays
@@ -70,7 +69,7 @@ module.exports.run = function(serviceConfig) {
 	const alertQueries = serviceConfig.alertInterval.map((interval) => ({
 		lastLogin: {
 			$lte:  new Date(Date.now() - interval).toISOString(),
-			$gt: new Date(Date.now() - interval - day).toISOString()
+			$gt: new Date(Date.now() - interval - 86400000).toISOString()
 		},
 		'roles.user': true
 	}));

--- a/src/app/core/user/inactive/inactive-user-email.service.spec.js
+++ b/src/app/core/user/inactive/inactive-user-email.service.spec.js
@@ -2,6 +2,7 @@
 
 const
 	should = require('should'),
+	moment = require('moment'),
 	proxyquire = require('proxyquire'),
 
 	deps = require('../../../../dependencies'),
@@ -22,14 +23,13 @@ function createSubjectUnderTest(dependencies) {
  */
 describe('User Email Service:', () => {
 
-	const day = 86400000;
 	const daysAgo = 90;
 
 	const user = {
 		name: 'test',
 		username: 'test',
 		email: 'test@test.test',
-		lastLogin: Date.now() - (day * daysAgo)
+		lastLogin: moment().subtract(daysAgo, 'day')
 	};
 
 	describe('sendEmail', () => {

--- a/src/app/core/user/inactive/inactive-user-email.service.spec.js
+++ b/src/app/core/user/inactive/inactive-user-email.service.spec.js
@@ -3,7 +3,6 @@
 const
 	should = require('should'),
 	proxyquire = require('proxyquire'),
-	moment = require('moment'),
 
 	deps = require('../../../../dependencies'),
 	config = deps.config;
@@ -23,12 +22,14 @@ function createSubjectUnderTest(dependencies) {
  */
 describe('User Email Service:', () => {
 
+	const day = 86400000;
 	const daysAgo = 90;
+
 	const user = {
 		name: 'test',
 		username: 'test',
 		email: 'test@test.test',
-		lastLogin: moment().subtract(daysAgo, 'days').toDate()
+		lastLogin: Date.now() - (day * daysAgo)
 	};
 
 	describe('sendEmail', () => {


### PR DESCRIPTION
The inactive email test was using momentjs and the subtract function to set the last login date for the email text, while the actual function was using native Date.now() and primitive subtraction of milliseconds.

As a result, the test was failing on certain computers/environments with a mismatch between the email text (89 vs 90 days).

This fix uses Date.now() in the test setup.

It could probably be argued that using moment() everywhere would be more accurate, but I'm no calendar mathematician.