### PR TITLE
Swagger 2.0 -> OpenAPI 3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1307,11 +1307,6 @@
       "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=",
       "dev": true
     },
-    "core-js": {
-      "version": "2.5.7",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
-      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
-    },
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -3136,7 +3131,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "optional": true,
@@ -4132,13 +4127,20 @@
       "dev": true
     },
     "json-schema-ref-parser": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-7.1.0.tgz",
-      "integrity": "sha512-eP9+39HimQUpmqEUHRpV+oh8hiVMRU2tD6H+8uDc0raCQxX6jARN4nSJe5OpAtPt7eObuIUIsW7AwvGBzCHavQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/json-schema-ref-parser/-/json-schema-ref-parser-7.1.4.tgz",
+      "integrity": "sha512-AD7bvav0vak1/63w3jH8F7eHId/4E4EPdMAEZhGxtjktteUv9dnNB/cJy6nVnMyoTPBJnLwFK6tiQPSTeleCtQ==",
       "requires": {
         "call-me-maybe": "^1.0.1",
         "js-yaml": "^3.13.1",
-        "ono": "^5.0.1"
+        "ono": "^6.0.0"
+      },
+      "dependencies": {
+        "ono": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ono/-/ono-6.0.1.tgz",
+          "integrity": "sha512-5rdYW/106kHqLeG22GE2MHKq+FlsxMERZev9DCzQX1zwkxnFwBivSn5i17a5O/rDmOJOdf4Wyt80UZljzx9+DA=="
+        }
       }
     },
     "json-schema-traverse": {
@@ -5563,7 +5565,7 @@
         },
         "find-up": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
           "dev": true,
           "requires": {
@@ -5588,7 +5590,7 @@
         },
         "locate-path": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
           "dev": true,
           "requires": {
@@ -5617,7 +5619,7 @@
         },
         "p-locate": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
           "dev": true,
           "requires": {
@@ -5638,13 +5640,13 @@
         },
         "resolve-from": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
           "dev": true
         },
         "rimraf": {
           "version": "2.6.3",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+          "resolved": false,
           "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
           "dev": true,
           "requires": {
@@ -5690,7 +5692,7 @@
         },
         "y18n": {
           "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+          "resolved": false,
           "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
           "dev": true
         },
@@ -5830,14 +5832,14 @@
       }
     },
     "ono": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/ono/-/ono-5.0.1.tgz",
-      "integrity": "sha512-4/4BPGHX8OuDDNx1SrOqTOI7zajPjvBvrG1jDG3hDq4qBpoKlzG2d83Vdz26hvv0FFWYsLdHf+1Vu/k2d8Ww9w=="
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/ono/-/ono-5.1.0.tgz",
+      "integrity": "sha512-GgqRIUWErLX4l9Up0khRtbrlH8Fyj59A0nKv8V6pWEto38aUgnOGOOF7UmgFFLzFnDSc8REzaTXOc0hqEe7yIw=="
     },
     "openapi-schemas": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/openapi-schemas/-/openapi-schemas-1.0.0.tgz",
-      "integrity": "sha512-KYy5vRmutd8ieqZQKWDAFEa7xiLXLkdWZljwLgxJV/5ydJqRIE9hMG5n9jTYtP5+fuZ3NhIYk2wIa+BCDoQpwg=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/openapi-schemas/-/openapi-schemas-1.0.3.tgz",
+      "integrity": "sha512-KtMWcK2VtOS+nD8RKSIyScJsj8JrmVWcIX7Kjx4xEHijFYuvMTDON8WfeKOgeSb4uNG6UsqLj5Na7nKbSav9RQ=="
     },
     "openapi-types": {
       "version": "1.3.5",
@@ -7452,26 +7454,26 @@
       }
     },
     "swagger-jsdoc": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-3.3.0.tgz",
-      "integrity": "sha512-O9I93uFM2/6QUPfRDW5I/dEcU54nwzjVpI0druO/EOXrGf3OKtj8wMdobGr45+ayD5uY58WrQ4hDhRa0238d0w==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/swagger-jsdoc/-/swagger-jsdoc-3.5.0.tgz",
+      "integrity": "sha512-TSmCgPodvVGGIXEU+zDp03Gau4pZxgVXiZMIjOgBQHEsRzPLoo2XvF9oQ8Nf1Wf29qsXebLb6qqlo6CIwCQ0Cw==",
       "requires": {
-        "commander": "2.20.0",
+        "commander": "4.0.1",
         "doctrine": "3.0.0",
-        "glob": "7.1.4",
+        "glob": "7.1.6",
         "js-yaml": "3.13.1",
-        "swagger-parser": "8.0.0"
+        "swagger-parser": "8.0.3"
       },
       "dependencies": {
         "commander": {
-          "version": "2.20.0",
-          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-          "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-4.0.1.tgz",
+          "integrity": "sha512-IPF4ouhCP+qdlcmCedhxX4xiGBPyigb8v5NeUp+0LyhwLgxMqyp3S0vl7TAPfS/hiP7FC3caI/PB9lTmP8r1NA=="
         },
         "glob": {
-          "version": "7.1.4",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
-          "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
+          "version": "7.1.6",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
           "requires": {
             "fs.realpath": "^1.0.0",
             "inflight": "^1.0.4",
@@ -7480,37 +7482,58 @@
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
           }
+        },
+        "swagger-parser": {
+          "version": "8.0.3",
+          "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-8.0.3.tgz",
+          "integrity": "sha512-y2gw+rTjn7Z9J+J1qwbBm0UL93k/VREDCveKBK6iGjf7KXC6QGshbnpEmeHL0ZkCgmIghsXzpNzPSbBH91BAEQ==",
+          "requires": {
+            "call-me-maybe": "^1.0.1",
+            "json-schema-ref-parser": "^7.1.1",
+            "ono": "^5.1.0",
+            "openapi-schemas": "^1.0.2",
+            "openapi-types": "^1.3.5",
+            "swagger-methods": "^2.0.1",
+            "z-schema": "^4.1.1"
+          }
         }
       }
     },
     "swagger-methods": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-2.0.0.tgz",
-      "integrity": "sha512-afMNP6XtF7w4XB2pFuF07JNrHGaKoppwC0O3Zrkv0PWGbMT3KyFYpk4lzdcax7RYV1JgMZeatX8ndYjL2y+0tQ=="
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/swagger-methods/-/swagger-methods-2.0.2.tgz",
+      "integrity": "sha512-/RNqvBZkH8+3S/FqBPejHxJxZenaYq3MrpeXnzi06aDIS39Mqf5YCUNb/ZBjsvFFt8h9FxfKs8EXPtcYdfLiRg=="
     },
     "swagger-parser": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-8.0.0.tgz",
-      "integrity": "sha512-zk6ig8J2B4OqCnBSIqO67/Ui96NTjuoX10YGa4YVlIlQzLpHUZbLFZaO+zSubQoqAiJxmpvlbUplEcFIsPCESA==",
+      "version": "8.0.4",
+      "resolved": "https://registry.npmjs.org/swagger-parser/-/swagger-parser-8.0.4.tgz",
+      "integrity": "sha512-KGRdAaMJogSEB7sPKI31ptKIWX8lydEDAwWgB4pBMU7zys5cd54XNhoPSVlTxG/A3LphjX47EBn9j0dOGyzWbA==",
       "requires": {
         "call-me-maybe": "^1.0.1",
-        "json-schema-ref-parser": "^7.1.0",
-        "ono": "^5.0.1",
-        "openapi-schemas": "^1.0.0",
+        "json-schema-ref-parser": "^7.1.3",
+        "ono": "^6.0.0",
+        "openapi-schemas": "^1.0.2",
         "openapi-types": "^1.3.5",
-        "swagger-methods": "^2.0.0",
-        "z-schema": "^4.1.0"
+        "swagger-methods": "^2.0.1",
+        "z-schema": "^4.2.2"
+      },
+      "dependencies": {
+        "ono": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/ono/-/ono-6.0.1.tgz",
+          "integrity": "sha512-5rdYW/106kHqLeG22GE2MHKq+FlsxMERZev9DCzQX1zwkxnFwBivSn5i17a5O/rDmOJOdf4Wyt80UZljzx9+DA=="
+        }
       }
     },
     "swagger-ui-dist": {
-      "version": "3.19.0",
-      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.19.0.tgz",
-      "integrity": "sha512-4/S7ZP8uPVn3vrCls46QG6RF4paqRFkDBcfSlyFetZHdPcjAu0hr38ZkaG4n8689R0tiqWDiubnEQUII+ulymA=="
+      "version": "3.25.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.25.0.tgz",
+      "integrity": "sha512-vwvJPPbdooTvDwLGzjIXinOXizDJJ6U1hxnJL3y6U3aL1d2MSXDmKg2139XaLBhsVZdnQJV2bOkX4reB+RXamg=="
     },
     "swagger-ui-express": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.0.1.tgz",
-      "integrity": "sha512-KCwnxnn27Me9dBjD5nMjhfrw6WaC/Ad/AaZw6YgIICLirFKCeG23s2Vf0VP/Y3TNt/xmJRvg6rMXN9T7CXClHQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.1.3.tgz",
+      "integrity": "sha512-f8SEn4YWkKh/HGK0ZjuA2VqA78i1aY6OIa5cqYNgOkBobfHV6Mz4dphQW/us8HYhEFfbENq329PyfIonWfzFrw==",
       "requires": {
         "swagger-ui-dist": "^3.18.1"
       }
@@ -8296,21 +8319,20 @@
       "integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk="
     },
     "z-schema": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.1.0.tgz",
-      "integrity": "sha512-C4In7uaih70TVnpCDtfnMeCjGRIkaikT8Yxqgz0GZrLJ3nkI5TsdRPOOjEYaebRnxGlbX68qeBSOBdbCufaqjQ==",
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/z-schema/-/z-schema-4.2.2.tgz",
+      "integrity": "sha512-7bGR7LohxSdlK1EOdvA/OHksvKGE4jTLSjd8dBj9YKT0S43N9pdMZ0Z7GZt9mHrBFhbNTRh3Ky6Eu2MHsPJe8g==",
       "requires": {
         "commander": "^2.7.1",
-        "core-js": "^2.5.7",
         "lodash.get": "^4.4.2",
         "lodash.isequal": "^4.5.0",
-        "validator": "^10.11.0"
+        "validator": "^11.0.0"
       },
       "dependencies": {
         "validator": {
-          "version": "10.11.0",
-          "resolved": "https://registry.npmjs.org/validator/-/validator-10.11.0.tgz",
-          "integrity": "sha512-X/p3UZerAIsbBfN/IwahhYaBbY68EN/UQBWHtsbXGT5bfrH/p4NQzUCG1kF/rtKaNpnJ7jAu6NGTdSNtyNIXMw=="
+          "version": "11.1.0",
+          "resolved": "https://registry.npmjs.org/validator/-/validator-11.1.0.tgz",
+          "integrity": "sha512-qiQ5ktdO7CD6C/5/mYV4jku/7qnqzjrxb3C/Q5wR3vGGinHTgJZN/TdFT3ZX4vXhX2R1PXx42fB1cn5W+uJ4lg=="
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -65,8 +65,9 @@
     "q": "1.5",
     "socket.io": "2.1",
     "socketio-sticky-session": "0.4",
-    "swagger-jsdoc": "3.3.0",
-    "swagger-ui-express": "4.0",
+    "swagger-jsdoc": "3.5.0",
+    "swagger-ui-express": "4.1.3",
+    "swagger-parser": "~8.0.4",
     "through2": "2.0",
     "uuid": "3.3"
   },

--- a/src/app/core/feedback/feedback.routes.js
+++ b/src/app/core/feedback/feedback.routes.js
@@ -10,59 +10,63 @@ const router = express.Router();
 
 /**
  * @swagger
- * definitions:
- *   Feedback:
- *     type: object
- *     properties:
- *       body:
- *          type: string
- *       url:
- *          type: string
- *       type:
- *          type: string
- *     example:
- *       body: 'This is a great tool! Thanks for building it.'
- *       url: 'http://localhost:3000/#/path/to/page'
- *       type: 'Bug'
+ * components:
+ *   schemas:
+ *     Feedback:
+ *       type: object
+ *       properties:
+ *         body:
+ *           type: string
+ *         url:
+ *           type: string
+ *         type:
+ *           type: string
+ *       example:
+ *         body: 'This is a great tool! Thanks for building it.'
+ *         url: 'http://localhost:3000/#/path/to/page'
+ *         type: 'Bug'
  */
 
 /**
  * @swagger
  * /feedback:
  *   post:
- *     produces:
- *       - application/json
  *     tags: [Feedback]
  *     description: >
  *       Echoes the feedback submitted, including the appended timestamp and user ID
- *     parameters:
- *       - in: body
- *         name: Feedback
- *         description: >
+ *     requestBody:
+ *       description: >
  *             The Feedback that is submitted by the user from some part
  *             of the application
- *         schema:
- *           $ref: '#/definitions/Feedback'
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             $ref: '#/components/schemas/Feedback'
  *     responses:
  *       '200':
  *         description: Feedback was submitted successfully
- *         schema:
- *           $ref: '#/definitions/Feedback'
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Feedback'
  *       '401':
  *         description: Anonymous user attempted to submit feedback
- *         schema:
- *           type: object
- *           properties:
- *             status:
- *               type: number
- *             type:
- *               type: string
- *             message:
- *               type: string
- *           example:
- *             status: 401
- *             type: 'no-login'
- *             message: 'User is not logged in'
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: number
+ *                 type:
+ *                   type: string
+ *                 message:
+ *                   type: string
+ *               example:
+ *                 status: 401
+ *                 type: 'no-login'
+ *                 message: 'User is not logged in'
  */
 router.route('/feedback')
 	.post(user.has(user.requiresLogin), feedback.submitFeedback);

--- a/src/app/core/user/user.routes.js
+++ b/src/app/core/user/user.routes.js
@@ -18,32 +18,33 @@ const router = express.Router();
 
 /**
  * @swagger
- * definitions:
- *   User:
- *     type: object
- *     properties:
- *       username:
- *          type: string
- *       name:
- *          type: string
- *     example:
- *       username: 'jbuser'
- *       name: 'Jane B. User'
+ * components:
+ *   schemas:
+ *     User:
+ *       type: object
+ *       properties:
+ *         username:
+ *           type: string
+ *         name:
+ *           type: string
+ *       example:
+ *         username: 'jbuser'
+ *         name: 'Jane B. User'
  */
 
 /**
  * @swagger
  * /user/me:
  *   get:
- *     produces:
- *       - application/json
  *     tags: [User]
  *     description: Returns information about the authenticated user.
  *     responses:
  *       '200':
  *         description: The authenticated user's profile
- *         schema:
- *           $ref: '#/definitions/User'
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/User'
  */
 // Self-service user routes
 router.route('/user/me')
@@ -98,30 +99,29 @@ router.route('/admin/users/getAll')
  * @swagger
  * /auth/signin:
  *   post:
- *     consumes:
- *       - application/json
- *     produces:
- *       - application/json
  *     tags: [Auth]
  *     description: authenticates the user.
- *     parameters:
- *       - in: body
- *         name: credentials
- *         schema:
- *           type: object
- *           properties:
- *             username:
- *               type: string
- *             password:
- *               type: string
- *           example:
- *             username: 'some_user'
- *             password: 'abc124'
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               username:
+ *                 type: string
+ *               password:
+ *                 type: string
+ *             example:
+ *               username: 'some_user'
+ *               password: 'abc124'
  *     responses:
  *       '200':
  *          description: The authenticated user's profile
- *          schema:
- *            $ref: '#/definitions/User'
+ *          content:
+ *            application/json:
+ *              schema:
+ *                $ref: '#/components/schemas/User'
  */
 router.route('/auth/signin').post(users.signin);
 
@@ -129,8 +129,6 @@ router.route('/auth/signin').post(users.signin);
  * @swagger
  * /auth/signout:
  *   get:
- *     produces:
- *       - application/json
  *     tags: [Auth]
  *     description: signs out the user.
  *     responses:

--- a/src/lib/express.js
+++ b/src/lib/express.js
@@ -212,6 +212,7 @@ function initSwaggerAPI(app) {
 
 	const swaggerOptions = {
 		swaggerDefinition: {
+			openapi: '3.0.2',
 			info: {
 				title: config.app.title,
 				description: config.app.description,

--- a/src/lib/express.js
+++ b/src/lib/express.js
@@ -212,7 +212,6 @@ function initSwaggerAPI(app) {
 
 	const swaggerOptions = {
 		swaggerDefinition: {
-			swagger: '2.0',
 			info: {
 				title: config.app.title,
 				description: config.app.description,

--- a/src/lib/express.spec.js
+++ b/src/lib/express.spec.js
@@ -16,12 +16,16 @@ describe('Init Swagger API:', () => {
 	it('Generated Swagger API should be valid', async () => {
 		const swaggerOptions = {
 			swaggerDefinition: {
+				openapi: '3.0.2',
 				info: {
 					title: config.app.title,
 					description: config.app.description,
 					version: 'test'
 				},
-				basePath: '/api'
+				servers: [{
+					url: 'https://api.example.com/api'
+				}]
+				// basePath: '/api'
 			},
 			apis: config.files.routes.map((route) => path.posix.resolve(route))
 		};

--- a/src/lib/express.spec.js
+++ b/src/lib/express.spec.js
@@ -16,7 +16,6 @@ describe('Init Swagger API:', () => {
 	it('Generated Swagger API should be valid', async () => {
 		const swaggerOptions = {
 			swaggerDefinition: {
-				swagger: '2.0',
 				info: {
 					title: config.app.title,
 					description: config.app.description,


### PR DESCRIPTION
- All of our swagger-based dependencies have been updated to the most recent version.
- swagger-parser has been added as a dependency (I'm unsure how the current one was working without this explicit dependency)
- express.js config and it's linked test suite have both been updated to validate against OpenAPI3