### PR TITLE
fix: Configure servers for openapi docs

### DIFF
--- a/src/lib/express.js
+++ b/src/lib/express.js
@@ -220,7 +220,9 @@ function initSwaggerAPI(app) {
 					email: _.get(config.mailer, 'from')
 				}
 			},
-			basePath: baseApiPath
+			servers: [{
+				url: baseApiPath
+			}]
 		},
 		apis: [
 			...config.files.routes.map((route) => path.posix.resolve(route)),


### PR DESCRIPTION
basePath config only applied to swagger 2.0 spec.  Need to specify servers for openapi.