### PR TITLE
fix: Ensure proper construction of paging results

### DIFF
--- a/src/app/core/audit/audit.controller.js
+++ b/src/app/core/audit/audit.controller.js
@@ -54,7 +54,7 @@ exports.search = function(req, res) {
 		});
 
 		// success
-		const toReturn = util.getPagingResults(page, limit, result.count, results);
+		const toReturn = util.getPagingResults(limit, page, result.count, results);
 
 		// Serialize the response
 		res.status(200).json(toReturn);

--- a/src/app/core/notifications/notification.service.js
+++ b/src/app/core/notifications/notification.service.js
@@ -23,7 +23,7 @@ function doSearch(query, sortParams, page, limit) {
 
 	return q.all([ countPromise, searchPromise ])
 		.then(([countResult, searchResult]) => {
-			return q(util.getPagingResults(page, limit, countResult, searchResult));
+			return q(util.getPagingResults(limit, page, countResult, searchResult));
 		});
 }
 

--- a/src/app/core/resources/resources.service.js
+++ b/src/app/core/resources/resources.service.js
@@ -62,7 +62,7 @@ module.exports = function() {
 			Resource.find(query).countDocuments(),
 			Resource.find(query).sort(sortParams).collation({caseLevel: true, locale: 'en'}).skip(offset).limit(limit)
 		]).then(([countResult, searchResult]) => {
-			return q(util.getPagingResults(page, limit, countResult, searchResult));
+			return q(util.getPagingResults(limit, page, countResult, searchResult));
 		});
 	}
 


### PR DESCRIPTION
Search audit call was not properly returning totalPages value, due to inversed parameters.  This fixes those and a couple of other similar errors.