### PR TITLE
build: update node version to 12

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,7 +6,7 @@
 	},
 
 	"parserOptions": {
-		"ecmaVersion": 8,
+		"ecmaVersion": 2019,
 		"sourceType": "module"
 	},
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com:Asymmetrik/node-rest-starter.git"
   },
   "engines": {
-    "node": ">=8.10.0",
+    "node": ">=12.14.0",
     "npm": ">=5.6.0",
     "yarn": ">=1.5.1"
   },


### PR DESCRIPTION
Not all that much involved here.  I've been running on node12 for the last couple weeks with no issue.
Updates engine in `package.json` and the ecmaVersion in `.eslintrc`.
Resolves #74 