### PR TITLE
#76 Updating feedback controller spec to use mock rerequire

### DIFF
--- a/src/app/core/feedback/feedback.controller.spec.js
+++ b/src/app/core/feedback/feedback.controller.spec.js
@@ -50,7 +50,7 @@ describe('Feedback Controller', () => {
 			}
 		});
 
-		router.use(require('./feedback.routes'));
+		router.use(mock.reRequire('./feedback.routes'));
 		app.use(router);
 	});
 


### PR DESCRIPTION
in order to guarantee a fresh copy of the feedback controller, reducing conflict from other tests.