### PR TITLE
Allow export to CSV from a readable stream

### DIFF
--- a/src/app/core/export/export-config.controller.js
+++ b/src/app/core/export/export-config.controller.js
@@ -46,11 +46,11 @@ exports.requestExport = (req, res) => {
 
 /**
  * Export a CSV file with rows derived from an array of objects
- * 
- * @param {Request} req 
- * @param {Response} res 
- * @param {string} filename 
- * @param {*} columns 
+ *
+ * @param {Request} req
+ * @param {Response} res
+ * @param {string} filename
+ * @param {*} columns
  * @param {any[]} data an array of objects containing data for rows
  */
 exports.exportCSV = (req, res, filename, columns, data) => {
@@ -70,12 +70,12 @@ exports.exportCSV = (req, res, filename, columns, data) => {
 
 /**
  * Export a CSV file with rows derived from a readable stream
- * 
- * @param {Request} req 
- * @param {Response} res 
- * @param {string} filename 
- * @param {*} columns 
- * @param {ReadableStream} stream a readable stream containing data for rows 
+ *
+ * @param {Request} req
+ * @param {Response} res
+ * @param {string} filename
+ * @param {*} columns
+ * @param {ReadableStream} stream a readable stream containing data for rows
  */
 exports.exportCSVFromStream = (req, res, filename, columns, stream) => {
 	res.set('Content-Type', 'text/csv;charset=utf-8');

--- a/src/app/core/export/export-config.controller.js
+++ b/src/app/core/export/export-config.controller.js
@@ -59,7 +59,7 @@ exports.exportCSV = (req, res, filename, columns, data) => {
 			req,
 			res,
 			filename,
-			'csv',
+			'text/csv',
 			buildExportStream(
 				data,
 				(stream) => () => {
@@ -87,7 +87,7 @@ exports.exportPlaintext = (req, res, filename, text) => {
 			req,
 			res,
 			filename,
-			'plain',
+			'text/plain',
 			buildExportStream(text, (stream) => () => {
 				text.split(os.EOL).forEach((row) => {
 					stream.push(row);
@@ -160,11 +160,11 @@ const buildExportStream = (data, getRead, transforms) => {
  * @param {*} req
  * @param {*} res
  * @param {string} fileName
- * @param {'csv' | 'plain'} fileType
+ * @param {string} contentType
  * @param {streams.Readable} stream
  */
-const exportStream = (req, res, fileName, fileType, stream) => {
-	res.set('Content-Type', `text/${fileType};charset=utf-8`);
+const exportStream = (req, res, fileName, contentType, stream) => {
+	res.set('Content-Type', `${contentType};charset=utf-8`);
 	res.set('Content-Disposition', `attachment;filename="${fileName}"`);
 	res.set('Transfer-Encoding', 'chunked');
 
@@ -175,7 +175,7 @@ const exportStream = (req, res, fileName, fileType, stream) => {
 	stream.on('error', (err) => {
 		logger.error(
 			err,
-			`${fileType === 'csv' ? 'CSV' : 'PlainText'} export error occurred`
+			`${contentType} export error occurred`
 		);
 
 		stream.destroy();
@@ -192,9 +192,7 @@ const exportStream = (req, res, fileName, fileType, stream) => {
 	req.on('close', () => {
 		if (!stream.destroyed) {
 			logger.info(
-				`${
-					fileType === 'csv' ? 'CSV' : 'PlainText'
-				} export aborted because client dropped the connection`
+				`${contentType} export aborted because client dropped the connection`
 			);
 
 			stream.destroy();

--- a/src/app/core/export/export-config.controller.js
+++ b/src/app/core/export/export-config.controller.js
@@ -2,8 +2,7 @@
 
 const
 	os = require('os'),
-	stream = require('stream'),
-
+	streams = require('stream'),
 	deps = require('../../../dependencies'),
 	dbs = deps.dbs,
 	utilService = deps.utilService,
@@ -44,104 +43,165 @@ exports.requestExport = (req, res) => {
 			});
 };
 
+
 /**
- * Export a CSV file with rows derived from an array of objects
+ * Export a CSV file with rows derived from an array of objects or a readable stream
  *
- * @param {Request} req
- * @param {Response} res
- * @param {string} filename
- * @param {*} columns
- * @param {any[]} data an array of objects containing data for rows
+ * @param {*} req
+ * @param {*} res
+ * @param {string} filename the name of the exported file
+ * @param {{ key: string, title: string, callback?: Function }[]} columns the columns to include in the exported CSV file
+ * @param {[] | streams.Readable} data an array of objects containing data for rows, or an instance of readable
  */
 exports.exportCSV = (req, res, filename, columns, data) => {
 	if (null !== data) {
-		// Put into stream the data object
-		const s = new stream.Readable({objectMode:true});
-		s._read = () => {
-			data.forEach((row) => {
-				s.push(row);
-			});
-			s.push(null);
-		};
-
-		this.exportCSVFromStream(req, res, filename, columns, s);
+		exportStream(
+			req,
+			res,
+			filename,
+			'csv',
+			buildExportStream(
+				data,
+				(stream) => () => {
+					data.forEach((row) => {
+						stream.push(row);
+					});
+					stream.push(null);
+				},
+				[csvStream(columns)]
+			)
+		);
 	}
 };
 
 /**
- * Export a CSV file with rows derived from a readable stream
- *
- * @param {Request} req
- * @param {Response} res
- * @param {string} filename
- * @param {*} columns
- * @param {ReadableStream} stream a readable stream containing data for rows
+ * Export a plain text file with content derived from a string or a readable stream
+ * @param {*} req
+ * @param {*} res
+ * @param {string} filename the name of the exported file
+ * @param {streams.Readable | string} text the text or readable stream to export
  */
-exports.exportCSVFromStream = (req, res, filename, columns, stream) => {
-	res.set('Content-Type', 'text/csv;charset=utf-8');
-	res.set('Content-Disposition', `attachment;filename="${filename}"`);
+exports.exportPlaintext = (req, res, filename, text) => {
+	if (null !== text) {
+		exportStream(
+			req,
+			res,
+			filename,
+			'plain',
+			buildExportStream(text, (stream) => () => {
+				text.split(os.EOL).forEach((row) => {
+					stream.push(row);
+				});
+				stream.push(null);
+			})
+		);
+	}
+};
+
+/**
+ * Build a readable stream from data and pipe through a chain of transform streams
+ *
+ * @param {streams.Readable | *} data the data to be exported, either in the form of a readable stream or an object accompanied by a getRead function
+ * @param {Function} getRead a function that takes a readable stream and returns the _read function for the new stream if data is not a readable stream
+ * @param {streams.Transform[]} [transforms] an optional array of transform streams through which to pipe the export data
+ */
+const buildExportStream = (data, getRead, transforms) => {
+	let stream = data;
+
+	if (!(stream instanceof streams.Readable)) {
+		stream = new streams.Readable({ objectMode: true });
+		stream._read = getRead(stream);
+	}
+
+	if (!stream.destroy) {
+		stream.destroy = () => {
+			stream.destroyed = true;
+		};
+	}
+
+	if (transforms && transforms.length) {
+		// reduce the initial stream and transform streams to a single stream
+		// destroying the resulting stream will also destroy all of the transform streams and the initial streams
+		stream = transforms.reduce((prevStream, transform) => {
+			// pipe previous stream through current transform stream
+			const newStream = prevStream.pipe(transform);
+
+			// if the previous stream has a defined `destroy()` function, we need to combine it with the newStream's destroy function
+			if (prevStream.destroy) {
+				// save the potentially undefined `destroy()` function from the new stream
+				const originalDestroy = newStream.destroy;
+
+				// we need to destroy both the new stream and the previous stream here
+				newStream.destroy = () => {
+					// newStream had a `destroy()` function already defined, use it
+					if (originalDestroy) {
+						originalDestroy.apply(this);
+					} else {
+						// the new stream did not have a defined `destroy()` function,
+						//  so we should mark it as `destroyed` at this point
+						newStream.destroyed = true;
+					}
+
+					// now destroy the previous stream
+					prevStream.destroy();
+				};
+			}
+
+			return newStream;
+		}, stream);
+	}
+
+	return stream;
+};
+
+/**
+ * Export to a file from a readable stream
+ *
+ * @param {*} req
+ * @param {*} res
+ * @param {string} fileName
+ * @param {'csv' | 'plain'} fileType
+ * @param {streams.Readable} stream
+ */
+const exportStream = (req, res, fileName, fileType, stream) => {
+	res.set('Content-Type', `text/${fileType};charset=utf-8`);
+	res.set('Content-Disposition', `attachment;filename="${fileName}"`);
 	res.set('Transfer-Encoding', 'chunked');
 
-	const sc = stream.pipe(csvStream(columns));
-
 	// Pipe each row to the response
-	sc.pipe(res);
+	stream.pipe(res);
 
 	// If an error occurs, close the stream
 	stream.on('error', (err) => {
-		logger.error(err, 'CSV export error occurred');
+		logger.error(
+			err,
+			`${fileType === 'csv' ? 'CSV' : 'PlainText'} export error occurred`
+		);
+
+		stream.destroy();
 
 		// End the download
 		res.end();
 	});
 
+	stream.on('end', () => {
+		stream.destroy();
+	});
+
 	// If the client drops the connection, stop processing the stream
 	req.on('close', () => {
-		logger.info('CSV export aborted because client dropped the connection');
-		if (stream != null) {
+		if (!stream.destroyed) {
+			logger.info(
+				`${
+					fileType === 'csv' ? 'CSV' : 'PlainText'
+				} export aborted because client dropped the connection`
+			);
+
 			stream.destroy();
 		}
+
 		// End the download.
 		res.end();
 	});
 };
 
-exports.exportPlaintext = (req, res, filename, text) => {
-
-	if (null !== text) {
-		// Set up streaming res
-		res.set('Content-Type', 'text/plain;charset=utf-8');
-		res.set('Content-Disposition', `attachment;filename="${filename}"`);
-		res.set('Transfer-Encoding', 'chunked');
-
-		// Put into stream the data object
-		const s = new stream.Readable({objectMode:true});
-		s._read = () => {
-			text.split(os.EOL).forEach((row) => {
-				s.push(row);
-			});
-			s.push(null);
-		};
-
-		// Pipe each row to the response
-		s.pipe(res);
-
-		// If an error occurs, close the stream
-		s.on('error', (err) => {
-			logger.error(err, 'Plaintext export error occurred');
-
-			// End the download
-			res.end();
-		});
-
-		// If the client drops the connection, stop processing the stream
-		req.on('close', () => {
-			logger.info('Plaintext export aborted because client dropped the connection');
-			if (s != null) {
-				s.destroy();
-			}
-			// End the download.
-			res.end();
-		});
-	}
-};


### PR DESCRIPTION
This PR extends the functionality of the CSV exporting by providing the ability to export directly from a readable stream. Specifically, this allows us to stream Mongoose cursors directly to a CSV without buffering the entirety of the query results in memory.