### PR TITLE
Refactor escapeRegex function to utils

### DIFF
--- a/src/app/common/mongoose/paging-search.plugin.js
+++ b/src/app/common/mongoose/paging-search.plugin.js
@@ -1,12 +1,9 @@
 const
 	deps = require('../../../dependencies'),
-	config = deps.config;
+	config = deps.config,
+	{ escapeRegex } = deps.utilService;
 
 const MONGO_TIMEOUT_ERROR_CODE = 50;
-
-function escapeRegex(str) {
-	return (`${str}`).replace(/[.?*+^$[\]\\(){}|-]/g, '\\$&');
-}
 
 function generateFilter(query) {
 	return Object.assign({}, query);

--- a/src/app/common/mongoose/paging-search.plugin.spec.js
+++ b/src/app/common/mongoose/paging-search.plugin.spec.js
@@ -12,25 +12,6 @@ const pagingSearchPlugin = rewire('../../common/mongoose/paging-search.plugin');
  */
 describe('Paging Search Plugin:', () => {
 
-	describe('escapeRegex:', () => {
-		const tests = [{
-			input: 'abcdef',
-			expected: 'abcdef',
-			description: 'Nothing to escape'
-		}, {
-			input: '.?*+^$[]\\(){}|-',
-			expected: '\\.\\?\\*\\+\\^\\$\\[\\]\\\\\\(\\)\\{\\}\\|\\-',
-			description: 'All of the characters to escape'
-		}];
-
-		tests.forEach((test) => {
-			it(test.description, () => {
-				const result = pagingSearchPlugin.__get__('escapeRegex')(test.input);
-				should(result).equal(test.expected);
-			});
-		});
-	});
-
 	describe('generateSort:', () => {
 		const tests = [{
 			input: null,

--- a/src/app/common/util.service.js
+++ b/src/app/common/util.service.js
@@ -377,3 +377,11 @@ module.exports.removeStringsEndingWithWildcard = (stringArray) => {
 		return _.endsWith(value, '*');
 	});
 };
+
+/**
+ * Escapes regex-specific characters in a given string
+ * @param {string} str
+ */
+module.exports.escapeRegex = (str) => {
+	return `${str}`.replace(/[.?*+^$[\]\\(){}|-]/g, '\\$&');
+};

--- a/src/app/common/util.service.spec.js
+++ b/src/app/common/util.service.spec.js
@@ -509,7 +509,7 @@ describe('Utils:', () => {
 		});
 	});
 
-	
+
 	describe('escapeRegex:', () => {
 		const tests = [{
 			input: 'abcdef',

--- a/src/app/common/util.service.spec.js
+++ b/src/app/common/util.service.spec.js
@@ -508,4 +508,25 @@ describe('Utils:', () => {
 			});
 		});
 	});
+
+	
+	describe('escapeRegex:', () => {
+		const tests = [{
+			input: 'abcdef',
+			expected: 'abcdef',
+			description: 'Nothing to escape'
+		}, {
+			input: '.?*+^$[]\\(){}|-',
+			expected: '\\.\\?\\*\\+\\^\\$\\[\\]\\\\\\(\\)\\{\\}\\|\\-',
+			description: 'All of the characters to escape'
+		}];
+
+		tests.forEach((test) => {
+			it(test.description, () => {
+				const result = util.escapeRegex(test.input);
+				should(result).equal(test.expected);
+			});
+		});
+	});
+
 });


### PR DESCRIPTION
This PR moves the `escapeRegex` function from the paging-search plugin to the utilities so that it can be used elsewhere.