### PR TITLE
refactor: Refactor handling of external roles into configurable provider

### DIFF
--- a/config/env/default.js
+++ b/config/env/default.js
@@ -52,13 +52,21 @@ module.exports = {
 		// defaultRoles: { user: true },
 		// requiredRoles: ['ROLE'],
 
+		roles: ['user', 'editor', 'auditor', 'admin'],
 		roleStrategy: 'local', // 'local' || 'external' || 'hybrid'
 
-		externalRoleMap: {
-			user: 'USER',
-			admin: 'ADMIN',
-			auditor: 'AUDITOR',
-			editor: 'EDITOR'
+		externalRoles: {
+			provider: {
+				file: 'src/app/core/user/auth/external-role-map.provider.js',
+				config: {
+					externalRoleMap: {
+						user: 'USER',
+						admin: 'ADMIN',
+						auditor: 'AUDITOR',
+						editor: 'EDITOR'
+					}
+				}
+			}
 		},
 
 		/**

--- a/src/app/core/user/admin/user-admin.controller.js
+++ b/src/app/core/user/admin/user-admin.controller.js
@@ -118,27 +118,8 @@ exports.adminDeleteUser = async (req, res) => {
 
 // Admin Search for Users
 exports.adminSearchUsers = async (req, res) => {
-	// Update role filters based on roleStrategy
-	const strategy = _.get(config, 'auth.roleStrategy', 'local');
-	const isExternal = strategy === 'external';
-	if ((isExternal || strategy === 'hybrid') && req.body.q && req.body.q.$or) {
-		const externalRoleMap = _.get(config, 'auth.externalRoleMap', {});
-		const updateRoleFilters = (role) => {
-			if (req.body.q.$or.some((filter) => filter[`roles.${role}`])) {
-				req.body.q.$or.push({ externalRoles: externalRoleMap[role] });
-				if (isExternal) {
-					_.remove(req.body.q.$or, (filter) => filter[`roles.${role}`]);
-				}
-			}
-		};
-
-		for (const role of _.keys(externalRoleMap)) {
-			updateRoleFilters(role);
-		}
-	}
-
 	// Handle the query/search/page
-	const query = req.body.q;
+	const query = userAuthorizationService.updateUserFilter(req.body.q);
 	const search = req.body.s;
 
 	try {

--- a/src/app/core/user/auth/external-role-map.provider.js
+++ b/src/app/core/user/auth/external-role-map.provider.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = function(config) {
+	return {
+		hasRole: (user, role) => {
+			const externalRoles = user.externalRoles || [];
+			return externalRoles.indexOf(config.externalRoleMap[role]) !== -1;
+		},
+
+		generateFilterForRole: (role) => {
+			return { externalRoles: config.externalRoleMap[role] };
+		}
+	};
+};

--- a/src/app/core/user/auth/user-authorization.service.js
+++ b/src/app/core/user/auth/user-authorization.service.js
@@ -1,39 +1,60 @@
 'use strict';
 
 const
-	_ = require('lodash');
-
+	_ = require('lodash'),
+	path = require('path'),
+	deps = require('../../../../dependencies');
 
 /**
  * ==========================================================
  * Private methods
  * ==========================================================
  */
+const getProvider = () => {
+	let provider;
+
+	const erConfig = _.get(deps.config, 'auth.externalRoles');
 
 
+	if (null != erConfig.provider) {
+		provider = require(path.posix.resolve(erConfig.provider.file))(erConfig.provider.config);
+	}
+
+	if (null == provider) {
+		throw new Error('No externalRoles provider configuration found.');
+	}
+
+	return provider;
+};
+
+const getRoleStrategy = () => _.get(deps.config, 'auth.roleStrategy', 'local');
+
+const getRoles = () => _.get(deps.config, 'auth.roles', ['user', 'editor', 'auditor', 'admin']);
 
 /**
  * ==========================================================
  * Public Methods
  * ==========================================================
  */
-module.exports.hasRoles = (user, roles, authConfig) => {
-	const strategy = _.get(authConfig, 'roleStrategy', 'local');
+
+module.exports.hasRoles = (user, roles) => {
+	const strategy = getRoleStrategy();
 
 	let toReturn = true;
 
 	if (null != roles) {
 		const localRoles = user.roles || [];
-		const externalRoles = user.externalRoles || [];
 
 		toReturn = roles.every((role) => {
 			const hasLocalRole = localRoles[role];
-			if (strategy === 'local')
+			if (strategy === 'local') {
 				return hasLocalRole;
+			}
 
-			const hasExternalRole = externalRoles.indexOf(authConfig.externalRoleMap[role]) !== -1;
-			if (strategy === 'external')
+			const hasExternalRole = getProvider().hasRole(user, role);
+			if (strategy === 'external') {
 				return hasExternalRole;
+			}
 
 			return hasLocalRole || hasExternalRole;
 		});
@@ -42,8 +63,8 @@ module.exports.hasRoles = (user, roles, authConfig) => {
 	return toReturn;
 };
 
-module.exports.updateRoles = (user, authConfig) => {
-	const strategy = _.get(authConfig, 'roleStrategy', 'local');
+module.exports.updateRoles = (user) => {
+	const strategy = getRoleStrategy();
 	const isHybrid = strategy === 'hybrid';
 
 	if (isHybrid) {
@@ -51,20 +72,33 @@ module.exports.updateRoles = (user, authConfig) => {
 	}
 	if (strategy === 'external' || isHybrid) {
 		const updatedRoles = {};
-		const externalRoles = user.externalRoles || [];
-		const externalRoleMap = authConfig.externalRoleMap;
-
-		const keys = _.keys(externalRoleMap);
-
-		keys.forEach((key) => {
-			updatedRoles[key] = (isHybrid && user.roles && user.roles[key]) || externalRoles.indexOf(externalRoleMap[key]) !== -1;
-		});
-
+		for (const key of getRoles()) {
+			updatedRoles[key] = (isHybrid && user.roles && user.roles[key]) || getProvider().hasRole(user, key);
+		}
 		user.roles = updatedRoles;
 	}
 };
 
-module.exports.checkExternalRoles = function(user, configAuth) {
+module.exports.updateUserFilter = (query) => {
+	// Update role filters based on roleStrategy
+	const strategy = getRoleStrategy();
+	const isExternal = strategy === 'external';
+
+	if ((isExternal || strategy === 'hybrid') && query && query.$or) {
+		for (const role of getRoles()) {
+			if (query.$or.some((filter) => filter[`roles.${role}`])) {
+				query.$or.push(getProvider().generateFilterForRole(role));
+				if (isExternal) {
+					_.remove(query.$or, (filter) => filter[`roles.${role}`]);
+				}
+			}
+		}
+	}
+
+	return query;
+};
+
+module.exports.checkExternalRoles = (user, configAuth) => {
 	// If there are required roles, check for them
 	if (null != configAuth && _.isArray(configAuth.requiredRoles) && configAuth.requiredRoles.length > 0) {
 		// Get the user roles
@@ -76,7 +110,7 @@ module.exports.checkExternalRoles = function(user, configAuth) {
 	return true;
 };
 
-module.exports.validateAccessToPersonalResource = function(user, resource) {
+module.exports.validateAccessToPersonalResource = (user, resource) => {
 	const isAdmin = null != user.roles && user.roles.admin === true;
 	if (isAdmin || resource.creator.equals(user._id)) {
 		return Promise.resolve();

--- a/src/app/core/user/auth/user-authorization.service.spec.js
+++ b/src/app/core/user/auth/user-authorization.service.spec.js
@@ -2,11 +2,24 @@
 
 const
 	should = require('should'),
+	sinon = require('sinon'),
 	mongoose = require('mongoose'),
+
+	deps = require('../../../../dependencies'),
 
 	userAuthorizationService = require('./user-authorization.service');
 
 describe('User authorization service:', () => {
+
+	let sandbox;
+
+	beforeEach(() => {
+		sandbox = sinon.createSandbox();
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
 
 	describe('validateAccessToPersonalResource', () => {
 		const id1 = mongoose.Types.ObjectId();
@@ -57,87 +70,104 @@ describe('User authorization service:', () => {
 
 	describe('updateRoles', () => {
 		it('roleStrategy === local; should pass through roles as is', () => {
+			sandbox.stub(deps.config.auth, 'roleStrategy').value('local');
+			sandbox.stub(deps.config.auth, 'roles').value(['user', 'elevatedRole1', 'elevatedRole2']);
+
 			const user = {
 				roles: {
 					user: true,
-					contentSteward: true,
-					equipmentSteward: false
+					elevatedRole1: true,
+					elevatedRole2: false
 				}
 			};
 
-			userAuthorizationService.updateRoles(user, {
-				roleStrategy: 'local'
-			});
+			userAuthorizationService.updateRoles(user);
 
 			user.should.be.an.Object();
 			user.roles.should.be.an.Object();
 			user.roles.user.should.be.true();
-			user.roles.contentSteward.should.be.true();
-			user.roles.equipmentSteward.should.be.false();
+			user.roles.elevatedRole1.should.be.true();
+			user.roles.elevatedRole2.should.be.false();
 
 			should.not.exist(user.localRoles);
 		});
 
 		it('roleStrategy === external; should pass through roles as is', () => {
+			sandbox.stub(deps.config.auth, 'roleStrategy').value('external');
+			sandbox.stub(deps.config.auth, 'roles').value(['user', 'elevatedRole1', 'elevatedRole2', 'admin']);
+			sandbox.stub(deps.config.auth, 'externalRoles').value({
+				provider: {
+					file: 'src/app/core/user/auth/external-role-map.provider.js',
+					config: {
+						externalRoleMap: {
+							user: 'USER',
+							elevatedRole1: 'ELEVATED_ROLE_1',
+							elevatedRole2: 'ELEVATED_ROLE_2',
+							admin: 'ADMIN'
+						}
+					}
+				}
+			});
+
 			const user = {
 				roles: {
 					user: true,
-					contentSteward: true,
-					equipmentSteward: false
+					elevatedRole1: true,
+					elevatedRole2: false
 				},
-				externalRoles: ['USER', 'EQUIPMENT_STEWARD']
+				externalRoles: ['USER', 'ELEVATED_ROLE_2']
 			};
 
-			userAuthorizationService.updateRoles(user, {
-				roleStrategy: 'external',
-				externalRoleMap: {
-					user: 'USER',
-					contentSteward: 'CONTENT_STEWARD',
-					equipmentSteward: 'EQUIPMENT_STEWARD',
-					admin: 'ADMIN'
-				}
-			});
+			userAuthorizationService.updateRoles(user);
 
 			user.should.be.an.Object();
 			user.roles.should.be.an.Object();
 			user.roles.user.should.be.true();
-			user.roles.contentSteward.should.be.false();
-			user.roles.equipmentSteward.should.be.true();
+			user.roles.elevatedRole1.should.be.false();
+			user.roles.elevatedRole2.should.be.true();
 
 			should.not.exist(user.localRoles);
 		});
 
 		it('roleStrategy === hybrid; should pass through roles as is', () => {
+			sandbox.stub(deps.config.auth, 'roleStrategy').value('hybrid');
+			sandbox.stub(deps.config.auth, 'roles').value(['user', 'elevatedRole1', 'elevatedRole2', 'admin']);
+			sandbox.stub(deps.config.auth, 'externalRoles').value({
+				provider: {
+					file: 'src/app/core/user/auth/external-role-map.provider.js',
+					config: {
+						externalRoleMap: {
+							user: 'USER',
+							elevatedRole1: 'ELEVATED_ROLE_1',
+							elevatedRole2: 'ELEVATED_ROLE_2',
+							admin: 'ADMIN'
+						}
+					}
+				}
+			});
+
 			const user = {
 				roles: {
 					user: true,
-					contentSteward: true,
-					equipmentSteward: false
+					elevatedRole1: true,
+					elevatedRole2: false
 				},
-				externalRoles: ['USER', 'EQUIPMENT_STEWARD']
+				externalRoles: ['USER', 'ELEVATED_ROLE_2']
 			};
 
-			userAuthorizationService.updateRoles(user, {
-				roleStrategy: 'hybrid',
-				externalRoleMap: {
-					user: 'USER',
-					contentSteward: 'CONTENT_STEWARD',
-					equipmentSteward: 'EQUIPMENT_STEWARD',
-					admin: 'ADMIN'
-				}
-			});
+			userAuthorizationService.updateRoles(user);
 
 			user.should.be.an.Object();
 			user.roles.should.be.an.Object();
 			user.roles.user.should.be.true();
-			user.roles.contentSteward.should.be.true();
-			user.roles.equipmentSteward.should.be.true();
+			user.roles.elevatedRole1.should.be.true();
+			user.roles.elevatedRole2.should.be.true();
 			user.roles.admin.should.be.false();
 
 			user.localRoles.should.be.an.Object();
 			user.localRoles.user.should.be.true();
-			user.localRoles.contentSteward.should.be.true();
-			user.localRoles.equipmentSteward.should.be.false();
+			user.localRoles.elevatedRole1.should.be.true();
+			user.localRoles.elevatedRole2.should.be.false();
 		});
 	});
 


### PR DESCRIPTION
Role handling has been centralized into `user-authorization.service.js`.  External role logic has been extracted into configurable provider.  Default provider implements existing role map logic.  Update to `user.model.js` to make user roles configurable.