### PR TITLE
Fixing the hasAccess method

### DIFF
--- a/src/app/core/user/user.controller.js
+++ b/src/app/core/user/user.controller.js
@@ -125,10 +125,10 @@ module.exports.requiresAny = (requirements) => {
 module.exports.hasAccess = (req, res, next) => {
 	module.exports.hasAll(
 			module.exports.requiresLogin,
-			module.exports.requiresEua,
 			module.exports.requiresOrganizationLevels,
 			module.exports.requiresUserRole,
-			module.exports.requiresExternalRoles
+			module.exports.requiresExternalRoles,
+			module.exports.requiresEua
 			)(req, res, next);
 };
 
@@ -140,11 +140,11 @@ module.exports.hasAccess = (req, res, next) => {
 module.exports.hasEditorAccess = (req, res, next) => {
 	module.exports.hasAll(
 			module.exports.requiresLogin,
-			module.exports.requiresEua,
 			module.exports.requiresOrganizationLevels,
 			module.exports.requiresUserRole,
 			module.exports.requiresExternalRoles,
-			module.exports.requiresEditorRole
+			module.exports.requiresEditorRole,
+			module.exports.requiresEua
 			)(req, res, next);
 };
 
@@ -156,11 +156,11 @@ module.exports.hasEditorAccess = (req, res, next) => {
 module.exports.hasAuditorAccess = (req, res, next) => {
 	module.exports.hasAll(
 			module.exports.requiresLogin,
-			module.exports.requiresEua,
 			module.exports.requiresOrganizationLevels,
 			module.exports.requiresUserRole,
 			module.exports.requiresExternalRoles,
-			module.exports.requiresAuditorRole
+			module.exports.requiresAuditorRole,
+			module.exports.requiresEua
 			)(req, res, next);
 };
 

--- a/src/app/core/user/user.controller.spec.js
+++ b/src/app/core/user/user.controller.spec.js
@@ -1,0 +1,101 @@
+'use strict';
+
+const mock = require('mock-require'),
+	should = require('should');
+
+/**
+ * Unit tests
+ */
+describe('User Controller:', () => {
+
+	const pass = (msg) => {
+		return () => {
+			return Promise.resolve(msg);
+		};
+	};
+	const fail = (msg) => {
+		return () => {
+			return Promise.reject({ message: msg });
+		};
+	};
+
+	describe('hasAccess', () => {
+
+		afterEach(() => {
+			mock.stopAll();
+		});
+
+		it('should allow a user with all access', (done) => {
+			mock('./auth/user-authorization.controller', {
+				requiresLogin: pass('login'),
+				requiresOrganizationLevels: pass('org'),
+				requiresUserRole: pass('user'),
+				requiresExternalRoles: pass('external')
+			});
+			mock('./eua/eua.controller', {
+				requiresEua: pass('eua')
+			});
+			const ctrl = mock.reRequire('./user.controller');
+			ctrl.hasAccess({}, {}, done);
+		});
+
+		it('should fail a user without eua access', (done) => {
+			mock('./auth/user-authorization.controller', {
+				requiresLogin: pass('login'),
+				requiresOrganizationLevels: pass('org'),
+				requiresUserRole: pass('user'),
+				requiresExternalRoles: pass('external')
+			});
+			mock('./eua/eua.controller', {
+				requiresEua: fail('eua')
+			});
+			const ctrl = mock.reRequire('./user.controller');
+			ctrl.hasAccess({}, { status: () => { return {
+				json: (actual) => {
+					should(actual.message).eql('eua');
+					done();
+				}
+			}; } }, () => { done('should not get here'); });
+		});
+
+		it('should fail a user without user role access', (done) => {
+			mock('./auth/user-authorization.controller', {
+				requiresLogin: pass('login'),
+				requiresOrganizationLevels: pass('org'),
+				requiresUserRole: fail('user'),
+				requiresExternalRoles: pass('external')
+			});
+			mock('./eua/eua.controller', {
+				requiresEua: pass('eua')
+			});
+			const ctrl = mock.reRequire('./user.controller');
+			ctrl.hasAccess({}, { status: () => { return {
+				json: (actual) => {
+					should(actual.message).eql('user');
+					done();
+				}
+			}; } }, () => { done('should not get here'); });
+		});
+
+		it('should fail first on user role even if eua is missing', (done) => {
+			mock('./auth/user-authorization.controller', {
+				requiresLogin: pass('login'),
+				requiresOrganizationLevels: pass('org'),
+				requiresUserRole: fail('user'),
+				requiresExternalRoles: pass('external')
+			});
+			mock('./eua/eua.controller', {
+				requiresEua: fail('eua')
+			});
+			const ctrl = mock.reRequire('./user.controller');
+			ctrl.hasAccess({}, { status: () => { return {
+				json: (actual) => {
+					should(actual.message).eql('user');
+					done();
+				}
+			}; } }, () => { done('should not get here'); });
+		});
+
+	});
+
+});


### PR DESCRIPTION
- hasAccess and other has* methods now check for EUA after all other user access and role checks
- Added partial test coverage to the user.controller for the hasAccess method

This fixes an issue where disabled user accounts ( those without the "user" role ) who also have not signed an EUA are stuck in an infinite loop on the UI since the EUA requires user authorization.