### PR TITLE
Updating the Swagger config for local auth

### DIFF
--- a/src/lib/express.js
+++ b/src/lib/express.js
@@ -231,9 +231,11 @@ function initSwaggerAPI(app) {
 	};
 
 	if (config.auth.strategy === 'local') {
-		swaggerOptions.swaggerDefinition.securityDefinitions = {
-			auth: {
-				type: 'basic'
+		swaggerOptions.swaggerDefinition.components = swaggerOptions.swaggerDefinition.components || {};
+		swaggerOptions.swaggerDefinition.components.securitySchemes = {
+			basicAuth: {
+				type: 'http',
+				scheme: 'basic'
 			}
 		};
 	}

--- a/src/lib/express.spec.js
+++ b/src/lib/express.spec.js
@@ -34,9 +34,12 @@ describe('Init Swagger API:', () => {
 		};
 
 		if (config.auth.strategy === 'local') {
-			swaggerOptions.swaggerDefinition.securityDefinitions = {
-				auth: {
-					type: 'basic'
+			swaggerOptions.swaggerDefinition.components = {
+				securitySchemes: {
+					basicAuth: {
+						type: 'http',
+						scheme: 'basic'
+					}
 				}
 			};
 		}


### PR DESCRIPTION
Swagger config for local auth now uses the latest OA3 spec. This fixes the express spec when run individually.