### PR TITLE
feat(teams): API support nested teams

### DIFF
--- a/config/env/default.js
+++ b/config/env/default.js
@@ -345,7 +345,8 @@ module.exports = {
 			 * membership in team.  User mush have one of the specified roles to be granted access to team.
 			 */
 			// strategy: 'teams'
-		}
+		},
+		nestedTeams: false
 	},
 
 	/**

--- a/src/app/core/resources/resources.service.js
+++ b/src/app/core/resources/resources.service.js
@@ -11,7 +11,7 @@ const
 	Team = dbs.admin.model('Team'),
 	User = dbs.admin.model('User'),
 
-	teamsController = require('../teams/teams.controller');
+	teamsService = require('../teams/teams.service');
 
 function populateOwnerAndCreatorInfo(search) {
 	search = search.toObject();
@@ -82,7 +82,7 @@ function searchResources(query, queryParams, user) {
 	let searchPromise;
 	// If user is not an admin, constrain the results to the user's teams
 	if (null == user.roles || !user.roles.admin) {
-		searchPromise = teamsController.filterTeamIds(user).then((teamIds) => {
+		searchPromise = teamsService.getMemberTeamIds(user).then((teamIds) => {
 			teamIds = teamIds.map((teamId) => _.isString(teamId) ? mongoose.Types.ObjectId(teamId) : teamId);
 
 			query.$or = [
@@ -124,7 +124,7 @@ function constrainTagResults(teamId, user, aggregation = true) {
 	}
 	else if (null == user.roles || !user.roles.admin) {
 		// If user is not admin, constrain results to user's teams
-		return teamsController.filterTeamIds(user).then((teamIds) => {
+		return teamsService.getMemberTeamIds(user).then((teamIds) => {
 			teamIds = teamIds.map((_teamId) => _.isString(_teamId) ? mongoose.Types.ObjectId(_teamId): _teamId);
 
 			const query = { $or: [
@@ -217,7 +217,7 @@ function filterResourcesByAccess(ids, user) {
 	}
 	else if (null == user.roles || user.roles.admin !== true) {
 		// If user is not admin, perform the filtering
-		return teamsController.filterTeamIds(user).then((teamIds) => {
+		return teamsService.getMemberTeamIds(user).then((teamIds) => {
 			// Get teams user has belongs to
 			teamIds = teamIds.map((teamId) => _.isString(teamId) ? mongoose.Types.ObjectId(teamId): teamId);
 

--- a/src/app/core/teams/team.model.js
+++ b/src/app/core/teams/team.model.js
@@ -81,6 +81,16 @@ const TeamSchema = new GetterSchema({
 	},
 	requiresExternalTeams: {
 		type: [String]
+	},
+	parent: {
+		type: mongoose.Schema.ObjectId,
+		ref: 'Team'
+	},
+	ancestors: {
+		type: [{
+			type: mongoose.Schema.ObjectId,
+			ref: 'Team'
+		}]
 	}
 });
 

--- a/src/app/core/teams/teams.controller.js
+++ b/src/app/core/teams/teams.controller.js
@@ -247,7 +247,15 @@ module.exports.updateMemberRole = async (req, res) => {
  * Team middleware
  */
 module.exports.teamById = async (req, res, next, id) => {
-	const team = await teamsService.readTeam(id);
+	const populate = [{
+		path: 'parent',
+		select: ['name']
+	}, {
+		path: 'ancestors',
+		select: ['name']
+	}];
+
+	const team = await teamsService.readTeam(id, populate);
 
 	if (null == team) {
 		return next(new Error('Could not find team'));

--- a/src/app/core/teams/teams.service.js
+++ b/src/app/core/teams/teams.service.js
@@ -268,6 +268,13 @@ const createTeam = async (teamInfo, creator, firstAdmin) => {
 	newTeam.updated = Date.now();
 	newTeam.creatorName = creator.name;
 
+	// Nested teams
+	if (teamInfo.parent) {
+		const parentTeam = await Team.findById(teamInfo.parent);
+		newTeam.parent = parentTeam._id;
+		newTeam.ancestors = [...parentTeam.ancestors, parentTeam._id];
+	}
+
 	let user = await User.findById(firstAdmin).exec();
 	user = User.filteredCopy(user);
 
@@ -323,9 +330,7 @@ const searchTeams = async (queryParams, query, search, user) => {
 
 	// If user is not an admin, constrain the results to the user's teams
 	if (!userAuthService.hasRoles(user, ['admin'], config.auth)) {
-		const [userTeams, implicitTeams] = await Promise.all([getMemberTeamIds(user), getImplicitTeamIds(user)]);
-
-		let teamIds = [...userTeams, ...implicitTeams];
+		let teamIds = await getMemberTeamIds(user);
 
 		// If the query already has a filter by team, take the intersection
 		if (null != query._id && null != query._id.$in) {
@@ -511,10 +516,7 @@ const requestNewTeam = async (org, aoi, description, requester, req) => {
 	}
 };
 
-/**
- * Team authorization Middleware
- */
-const getImplicitTeamIds = (user) => {
+const getExplicitTeamIds = (user, ...roles) => {
 	// Validate the user input
 	if (null == user) {
 		return Promise.reject({status: 401, type: 'bad-request', message: 'User does not exist'});
@@ -524,10 +526,33 @@ const getImplicitTeamIds = (user) => {
 		user = user.toObject();
 	}
 
+	let userTeams = (_.isArray(user.teams)) ? user.teams : [];
+	if (roles && roles.length > 0) {
+		userTeams = userTeams.filter((t) => null != t.role && roles.includes(t.role));
+	}
+
+	const userTeamIds = userTeams.map((t) => t._id.toString());
+
+	return Promise.resolve(userTeamIds);
+};
+
+/**
+ * Team authorization Middleware
+ */
+const getImplicitTeamIds = (user, ...roles) => {
+	// Validate the user input
+	if (null == user) {
+		return Promise.reject({status: 401, type: 'bad-request', message: 'User does not exist'});
+	}
+
 	const strategy = _.get(config, 'teams.implicitMembers.strategy', null);
 
-	if (strategy == null) {
+	if (strategy == null || (roles.length > 0 && !roles.includes('member'))) {
 		return Promise.resolve([]);
+	}
+
+	if (user.constructor.name === 'model') {
+		user = user.toObject();
 	}
 
 	const query = {$and: [{implicitMembers: true}]};
@@ -555,24 +580,23 @@ const getImplicitTeamIds = (user) => {
 	return Team.distinct('_id', query).exec();
 };
 
-const getTeamIds = (user, ...roles) => {
-	// Validate the user input
-	if (null == user) {
-		return Promise.reject({status: 401, type: 'bad-request', message: 'User does not exist'});
+const getNestedTeamIds = async (teamIds = []) => {
+	const nestedTeamsEnabled = _.get(config, 'teams.nestedTeams', false);
+	if (!nestedTeamsEnabled || teamIds.length === 0) {
+		return Promise.resolve([]);
 	}
 
-	if (user.constructor.name === 'model') {
-		user = user.toObject();
-	}
+	const mappedTeamIds = teamIds.map((teamId) => _.isString(teamId) ? mongoose.Types.ObjectId(teamId) : teamId);
 
-	let userTeams = (_.isArray(user.teams)) ? user.teams : [];
-	if (roles && roles.length > 0) {
-		userTeams = userTeams.filter((t) => null != t.role && roles.includes(t.role));
-	}
+	return await Team.distinct('_id', { _id: { $nin: mappedTeamIds }, ancestors: { $in: mappedTeamIds } }).exec();
+};
 
-	const filteredTeamIds = userTeams.map((t) => t._id.toString());
+const getTeamIds = async (user, ...roles) => {
+	const explicitTeamIds = await getExplicitTeamIds(user, ...roles);
+	const implicitTeamIds = await getImplicitTeamIds(user, ...roles);
+	const nestedTeamIds = await getNestedTeamIds([...explicitTeamIds, ...implicitTeamIds]);
 
-	return Promise.resolve(filteredTeamIds);
+	return [...explicitTeamIds, ...implicitTeamIds, ...nestedTeamIds];
 };
 
 const getMemberTeamIds = (user) => getTeamIds(user, 'member', 'editor', 'admin');
@@ -611,12 +635,14 @@ module.exports = {
 	updateMemberRole,
 	removeMemberFromTeam,
 	sendRequestEmail,
+	getExplicitTeamIds,
+	getImplicitTeamIds,
+	getNestedTeamIds,
 	getTeamIds,
-	filterTeamIds,
 	getMemberTeamIds,
 	getEditorTeamIds,
 	getAdminTeamIds,
-	getImplicitTeamIds,
+	filterTeamIds,
 	readTeam,
 	readTeamMember
 };

--- a/src/app/core/teams/teams.service.spec.js
+++ b/src/app/core/teams/teams.service.spec.js
@@ -66,7 +66,7 @@ function teamSpec(key) {
  */
 describe('Team Service:', () => {
 	// Specs for tests
-	const spec = { team: {}, user: {}, userTeams: {} };
+	const spec = { team: {}, nestedTeam: {}, user: {}, userTeams: {} };
 
 	// Teams for tests
 	spec.team.teamWithExternalTeam = teamSpec('external-team');
@@ -276,7 +276,8 @@ describe('Team Service:', () => {
 
 		it('null admin should default admin to creator', async () => {
 			const queryParams = {dir: 'ASC', page: '0', size: '5', sort: 'name'};
-			const creator = await User.findOne({name: 'user1 Name'}).exec();
+			// const creator = await User.findOne({name: 'user1 Name'}).exec();
+			const creator = user.user1;
 
 			// null admin should default to creator
 			await teamsService.createTeam(teamSpec('test-create'), creator, null);
@@ -284,6 +285,21 @@ describe('Team Service:', () => {
 			const members = await teamsService.searchTeamMembers(null, {}, queryParams, _team);
 			(members.elements).should.have.length(1);
 			(members.elements[0]).name.should.equal(creator.name);
+		});
+
+		it('nested team created', async () => {
+			const creator = user.user1;
+
+			let _team = teamSpec('nested-team');
+			_team.parent = team.teamWithNoExternalTeam._id;
+
+			await teamsService.createTeam(_team, creator, null);
+			_team = await Team.findOne({name: 'nested-team'}).exec();
+
+			should.exist(_team);
+			_team.should.be.Object();
+			_team.parent.toString().should.equal(team.teamWithNoExternalTeam._id.toString());
+			_team.ancestors.length.should.equal(1);
 		});
 	});
 
@@ -1040,23 +1056,127 @@ describe('Team Service:', () => {
 
 	});
 
+	describe('getNestedTeamIds', () => {
+		beforeEach(async() => {
+			spec.nestedTeam.nestedTeam1 = teamSpec('nested-team-1');
+			spec.nestedTeam.nestedTeam2 = teamSpec('nested-team-2');
+			spec.nestedTeam.nestedTeam3 = teamSpec('nested-team-3');
+			spec.nestedTeam.nestedTeam1_1 = teamSpec('nested-team-1-1');
+			spec.nestedTeam.nestedTeam1_2 = teamSpec('nested-team-1-2');
+			spec.nestedTeam.nestedTeam2_1 = teamSpec('nested-team-2-1');
+
+			// Create nested teams
+			let t = new Team({
+				...spec.nestedTeam.nestedTeam1,
+				parent: team.teamWithNoExternalTeam._id,
+				ancestors: [ team.teamWithNoExternalTeam._id ]
+			});
+			team.nestedTeam1 = await t.save();
+
+			t = new Team({
+				...spec.nestedTeam.nestedTeam2,
+				parent: team.teamWithNoExternalTeam._id,
+				ancestors: [ team.teamWithNoExternalTeam._id ]
+			});
+			team.nestedTeam2 = await t.save();
+
+			t = new Team({
+				...spec.nestedTeam.nestedTeam3,
+				parent: team.teamWithNoExternalTeam._id,
+				ancestors: [ team.teamWithNoExternalTeam._id ]
+			});
+			team.nestedTeam3 = await t.save();
+
+			t = new Team({
+				...spec.nestedTeam.nestedTeam1_1,
+				parent: team.nestedTeam1._id,
+				ancestors: [ team.teamWithNoExternalTeam._id, team.nestedTeam1._id ]
+			});
+			team.nestedTeam1_1 = await t.save();
+
+			t = new Team({
+				...spec.nestedTeam.nestedTeam1_2,
+				parent: team.nestedTeam1._id,
+				ancestors: [ team.teamWithNoExternalTeam._id, team.nestedTeam1._id ]
+			});
+			team.nestedTeam1_2 = await t.save();
+
+			t = new Team({
+				...spec.nestedTeam.nestedTeam2_1,
+				parent: team.nestedTeam2._id,
+				ancestors: [ team.teamWithNoExternalTeam._id, team.nestedTeam2._id ]
+			});
+			team['nestedTeam2_1'] = await t.save();
+		});
+
+		it('return empty array if nestedTeams is disabled in config', async () => {
+			sandbox.stub(deps.config.teams, 'nestedTeams').value(false);
+
+			const nestedTeamIds = await teamsService.getNestedTeamIds([team.teamWithNoExternalTeam._id]);
+
+			should.exist(nestedTeamIds);
+			nestedTeamIds.should.be.Array();
+			nestedTeamIds.length.should.equal(0);
+		});
+
+		it('undefined parent teams', async () => {
+			sandbox.stub(deps.config.teams, 'nestedTeams').value(true);
+
+			const nestedTeamIds = await teamsService.getNestedTeamIds();
+
+			should.exist(nestedTeamIds);
+			nestedTeamIds.should.be.Array();
+			nestedTeamIds.length.should.equal(0);
+		});
+
+		it('empty parent teams array', async () => {
+			sandbox.stub(deps.config.teams, 'nestedTeams').value(true);
+
+			const nestedTeamIds = await teamsService.getNestedTeamIds([]);
+
+			should.exist(nestedTeamIds);
+			nestedTeamIds.should.be.Array();
+			nestedTeamIds.length.should.equal(0);
+		});
+
+		it('default/all roles', async () => {
+			sandbox.stub(deps.config.teams, 'nestedTeams').value(true);
+
+			const nestedTeamIds = await teamsService.getNestedTeamIds([team.teamWithNoExternalTeam._id]);
+
+			should.exist(nestedTeamIds);
+			nestedTeamIds.should.be.Array();
+			nestedTeamIds.length.should.equal(6);
+		});
+
+		it('explicitly pass "member" role', async () => {
+			sandbox.stub(deps.config.teams, 'nestedTeams').value(true);
+
+			const nestedTeamIds = await teamsService.getNestedTeamIds([team.nestedTeam1._id]);
+
+			should.exist(nestedTeamIds);
+			nestedTeamIds.should.be.Array();
+			nestedTeamIds.length.should.equal(2);
+		});
+	});
+
 	describe('getTeamIds', () => {
 		const _user = {
 			teams: [{
-				_id: 1, role: 'member'
+				_id: '000000000000000000000001', role: 'member'
 			}, {
-				_id: 2, role: 'member'
+				_id: '000000000000000000000002', role: 'member'
 			}, {
-				_id: 3, role: 'editor'
+				_id: '000000000000000000000003', role: 'editor'
 			}, {
-				_id: 4, role: 'admin'
+				_id: '000000000000000000000004', role: 'admin'
 			}, {
-				_id: 5, role: 'editor'
+				_id: '000000000000000000000005', role: 'editor'
 			}]
 		};
 
 		it('should reject for non-existent user', async () => {
-			await teamsService.getTeamIds(null).should.be.rejectedWith({
+			await teamsService.getExplicitTeamIds(null).should.be.rejectedWith({
 				status: 401,
 				type: 'bad-request',
 				message: 'User does not exist'
@@ -1065,7 +1185,7 @@ describe('Team Service:', () => {
 
 
 		it('should return no teams for user with empty teams array', async () => {
-			const teamIds = await teamsService.getTeamIds({ teams: [] });
+			const teamIds = await teamsService.getExplicitTeamIds({ teams: [] });
 
 			should.exist(teamIds, 'expected teamIds to exist');
 			teamIds.length.should.equal(0);
@@ -1073,7 +1193,7 @@ describe('Team Service:', () => {
 		});
 
 		it('should return no teams for user with no teams array', async () => {
-			const teamIds = await teamsService.getTeamIds({ });
+			const teamIds = await teamsService.getExplicitTeamIds({ });
 
 			should.exist(teamIds, 'expected teamIds to exist');
 			teamIds.length.should.equal(0);
@@ -1081,7 +1201,7 @@ describe('Team Service:', () => {
 		});
 
 		it('should return all team ids when roles is not specified', async () => {
-			const teamIds = await teamsService.getTeamIds(_user);
+			const teamIds = await teamsService.getExplicitTeamIds(_user);
 
 			should.exist(teamIds, 'expected teamIds to exist');
 			teamIds.length.should.equal(5);
@@ -1092,32 +1212,32 @@ describe('Team Service:', () => {
 		});
 
 		it('should return only team ids where user is a member', async () => {
-			const teamIds = await teamsService.getTeamIds(_user, 'member');
+			const teamIds = await teamsService.getExplicitTeamIds(_user, 'member');
 
 			should.exist(teamIds, 'expected teamIds to exist');
 			teamIds.length.should.equal(2);
 
-			teamIds[0].should.equal('1');
-			teamIds[1].should.equal('2');
+			teamIds[0].should.equal('000000000000000000000001');
+			teamIds[1].should.equal('000000000000000000000002');
 		});
 
 		it('should return only team ids where user is an editor', async () => {
-			const teamIds = await teamsService.getTeamIds(_user, 'editor');
+			const teamIds = await teamsService.getExplicitTeamIds(_user, 'editor');
 
 			should.exist(teamIds, 'expected teamIds to exist');
 			teamIds.length.should.equal(2);
 
-			teamIds[0].should.equal('3');
-			teamIds[1].should.equal('5');
+			teamIds[0].should.equal('000000000000000000000003');
+			teamIds[1].should.equal('000000000000000000000005');
 		});
 
 		it('should return only team ids where user is an admin', async () => {
-			const teamIds = await teamsService.getTeamIds(_user, 'admin');
+			const teamIds = await teamsService.getExplicitTeamIds(_user, 'admin');
 
 			should.exist(teamIds, 'expected teamIds to exist');
 			teamIds.length.should.equal(1);
 
-			teamIds[0].should.equal('4');
+			teamIds[0].should.equal('000000000000000000000004');
 		});
 
 		it('should find all team members', async () => {
@@ -1142,35 +1262,35 @@ describe('Team Service:', () => {
 	describe('filterTeamIds', () => {
 		const _user = {
 			teams: [{
-				_id: 1, role: 'member'
+				_id: '000000000000000000000001', role: 'member'
 			}, {
-				_id: 2, role: 'member'
+				_id: '000000000000000000000002', role: 'member'
 			}, {
-				_id: 3, role: 'editor'
+				_id: '000000000000000000000003', role: 'editor'
 			}, {
-				_id: 4, role: 'admin'
+				_id: '000000000000000000000004', role: 'admin'
 			}, {
-				_id: 5, role: 'editor'
+				_id: '000000000000000000000005', role: 'editor'
 			}]
 		};
 
 		it ('should filter teamIds for membership (basic)', async () => {
-			const teamIds = await teamsService.filterTeamIds(_user, ['1']);
+			const teamIds = await teamsService.filterTeamIds(_user, ['000000000000000000000001']);
 			should.exist(teamIds);
 			teamIds.should.have.length(1);
-			should(teamIds[0]).equal('1');
+			should(teamIds[0]).equal('000000000000000000000001');
 		});
 
 		it ('should filter teamIds for membership (advanced)', async () => {
-			const teamIds = await teamsService.filterTeamIds(_user, [ '1', '2']);
+			const teamIds = await teamsService.filterTeamIds(_user, [ '000000000000000000000001', '000000000000000000000002']);
 			should.exist(teamIds);
 			teamIds.should.have.length(2);
-			should(teamIds[0]).equal('1');
-			should(teamIds[1]).equal('2');
+			should(teamIds[0]).equal('000000000000000000000001');
+			should(teamIds[1]).equal('000000000000000000000002');
 		});
 
 		it ('should filter teamIds for membership when no access', async () => {
-			const teamIds = await teamsService.filterTeamIds(_user, [ '6' ]);
+			const teamIds = await teamsService.filterTeamIds(_user, [ '000000000000000000000006' ]);
 			should.exist(teamIds);
 			teamIds.should.have.length(0);
 		});
@@ -1179,11 +1299,11 @@ describe('Team Service:', () => {
 			const teamIds = await teamsService.filterTeamIds(_user);
 			should.exist(teamIds);
 			teamIds.should.have.length(5);
-			should(teamIds[0]).equal('1');
-			should(teamIds[1]).equal('2');
-			should(teamIds[2]).equal('3');
-			should(teamIds[3]).equal('4');
-			should(teamIds[4]).equal('5');
+			should(teamIds[0]).equal('000000000000000000000001');
+			should(teamIds[1]).equal('000000000000000000000002');
+			should(teamIds[2]).equal('000000000000000000000003');
+			should(teamIds[3]).equal('000000000000000000000004');
+			should(teamIds[4]).equal('000000000000000000000005');
 		});
 	});
 

--- a/src/app/core/user/profile/user-profile.controller.js
+++ b/src/app/core/user/profile/user-profile.controller.js
@@ -14,14 +14,15 @@ const
 
 	userAuthorizationService = require('../auth/user-authorization.service'),
 	userService = require('../user.service'),
-	userProfileService = require('./user-profile.service');
+	userProfileService = require('./user-profile.service'),
+	teamService = require('../../teams/teams.service');
 
 /**
  * Standard User Operations
  */
 
 // Get Current User
-exports.getCurrentUser = (req, res) => {
+exports.getCurrentUser = async (req, res) => {
 
 	// The user that is a parameter of the request is stored in 'userParam'
 	const user = req.user;
@@ -36,6 +37,8 @@ exports.getCurrentUser = (req, res) => {
 	const userCopy = User.fullCopy(user);
 
 	userAuthorizationService.updateRoles(userCopy, config.auth);
+
+	await teamService.updateTeams(userCopy);
 
 	res.status(200).json(userCopy);
 };


### PR DESCRIPTION
Adds api support for creating nested teams by accepting a parent team on creation.
Team lookup logic updated to handle nested teams.