### PR TITLE
fix(teams): Ensure delete team is removed from all user objects.

### DIFF
--- a/src/app/core/teams/teams.controller.js
+++ b/src/app/core/teams/teams.controller.js
@@ -68,7 +68,7 @@ module.exports.delete = async (req, res) => {
 	}
 
 	try {
-		await teamsService.deleteTeam(req.team, req.user, req.headers);
+		await teamsService.deleteTeam(req.team);
 
 		// Audit the team delete attempt
 		await auditService.audit('team deleted', 'team', 'delete', TeamMember.auditCopy(req.user, util.getHeaderField(req.headers, 'x-real-ip')), Team.auditCopy(req.team), req.headers);
@@ -211,7 +211,7 @@ module.exports.removeMember = async (req, res) => {
 	}
 
 	try {
-		await teamsService.removeMemberFromTeam(req.userParam, req.team, req.user, req.headers);
+		await teamsService.removeMemberFromTeam(req.userParam, req.team);
 
 		// Audit the user remove
 		await auditService.audit('team member removed', 'team-role', 'user remove',
@@ -231,7 +231,7 @@ module.exports.updateMemberRole = async (req, res) => {
 	const role = req.body.role || 'member';
 
 	try {
-		await teamsService.updateMemberRole(req.userParam, req.team, role, req.user, req.headers);
+		await teamsService.updateMemberRole(req.userParam, req.team, role);
 
 		// Audit the member update request
 		await auditService.audit(`team role changed to ${role}`, 'team-role', 'user add',

--- a/src/app/core/teams/teams.service.js
+++ b/src/app/core/teams/teams.service.js
@@ -315,7 +315,7 @@ const deleteTeam = async (team) => {
 	// Delete the team and update all members in the team
 	return Promise.all([
 		team.delete(),
-		TeamMember.updateOne(
+		TeamMember.updateMany(
 			{ 'teams._id': team._id },
 			{ $pull: { teams: { _id: team._id } } }
 		).exec()
@@ -416,7 +416,7 @@ const addMemberToTeam = (user, team, role) => {
 	}).exec();
 };
 
-const updateMemberRole = async (user, team, role, requester, headers) => {
+const updateMemberRole = async (user, team, role) => {
 	const currentRole = getTeamRole(user, team);
 
 	if (null != currentRole && currentRole === 'admin') {
@@ -437,10 +437,9 @@ const updateMemberRole = async (user, team, role, requester, headers) => {
  *
  * @param user The user to remove
  * @param team The team object
- * @param requester The user requesting the removal
  * @returns {Promise} Returns a promise that resolves if the user is successfully removed from the team, and rejects otherwise
  */
-const removeMemberFromTeam = async (user, team, requester, headers) => {
+const removeMemberFromTeam = async (user, team) => {
 	// Verify the user is not the last admin in the team
 	await verifyNotLastAdmin(user, team);
 

--- a/src/app/core/teams/teams.service.spec.js
+++ b/src/app/core/teams/teams.service.spec.js
@@ -324,7 +324,7 @@ describe('Team Service:', () => {
 		it('should delete team, if team has no resources', async () => {
 			const beforeTeamCount = await Team.count({});
 
-			await teamsService.deleteTeam(team.teamWithNoExternalTeam, user.user1)
+			await teamsService.deleteTeam(team.teamWithNoExternalTeam)
 				.should.be.fulfilled();
 
 			// Verify Team no longer exists
@@ -351,7 +351,7 @@ describe('Team Service:', () => {
 			});
 			await resource.save();
 
-			await teamsService.deleteTeam(team.teamWithNoExternalTeam, user.user1)
+			await teamsService.deleteTeam(team.teamWithNoExternalTeam)
 				.should.be.rejectedWith({
 					status: 400,
 					type: 'bad-request',
@@ -479,7 +479,7 @@ describe('Team Service:', () => {
 
 	describe('updateMemberRole', () => {
 		it('update role', async () => {
-			await teamsService.updateMemberRole(user.explicit, team.teamWithNoExternalTeam, 'admin', user.admin);
+			await teamsService.updateMemberRole(user.explicit, team.teamWithNoExternalTeam, 'admin');
 
 			const uResult = await TeamMember.findById(user.explicit._id);
 			const userTeam = uResult.teams.find((t) => t._id.equals(team.teamWithNoExternalTeam._id));
@@ -490,12 +490,12 @@ describe('Team Service:', () => {
 		it('downgrade admin role; succeed if team has other admins', async () => {
 			await teamsService.addMemberToTeam(user.user2, team.teamWithNoExternalTeam, 'admin');
 
-			await teamsService.updateMemberRole(user.user3, team.teamWithNoExternalTeam, 'member', user.admin)
+			await teamsService.updateMemberRole(user.user3, team.teamWithNoExternalTeam, 'member')
 				.should.be.fulfilled();
 		});
 
 		it('downgrade admin role; reject if team has no other admins', async () => {
-			await teamsService.updateMemberRole(user.user3, team.teamWithNoExternalTeam, 'member', user.admin)
+			await teamsService.updateMemberRole(user.user3, team.teamWithNoExternalTeam, 'member')
 				.should.be.rejectedWith({
 					status: 400,
 					type: 'bad-request',
@@ -504,7 +504,7 @@ describe('Team Service:', () => {
 		});
 
 		it('reject for invalid team role', async () => {
-			await teamsService.updateMemberRole(user.user1, team.teamWithNoExternalTeam, 'fake-role', user.admin)
+			await teamsService.updateMemberRole(user.user1, team.teamWithNoExternalTeam, 'fake-role')
 				.should.be.rejectedWith({
 					status: 400,
 					type: 'bad-argument',
@@ -517,12 +517,12 @@ describe('Team Service:', () => {
 		it('remove admin user; succeed if team has other admins', async () => {
 			await teamsService.addMemberToTeam(user.user2, team.teamWithNoExternalTeam, 'admin');
 
-			await teamsService.removeMemberFromTeam(user.user3, team.teamWithNoExternalTeam, user.admin)
+			await teamsService.removeMemberFromTeam(user.user3, team.teamWithNoExternalTeam)
 				.should.be.fulfilled();
 		});
 
 		it('remove admin user; reject if team has no other admins', async () => {
-			await teamsService.removeMemberFromTeam(user.user3, team.teamWithNoExternalTeam, user.admin)
+			await teamsService.removeMemberFromTeam(user.user3, team.teamWithNoExternalTeam)
 				.should.be.rejectedWith({
 					status: 400,
 					type: 'bad-request',

--- a/src/app/core/teams/teams.service.spec.js
+++ b/src/app/core/teams/teams.service.spec.js
@@ -336,9 +336,8 @@ describe('Team Service:', () => {
 			afterTeamCount.should.equal(beforeTeamCount - 1);
 
 			// Verify team entry is removed from user
-			const uResult = await TeamMember.findById(user.explicit._id);
-			const userTeam = uResult.teams.find((t) => t._id.equals(team.teamWithNoExternalTeam._id));
-			should.not.exist(userTeam);
+			const count = await TeamMember.count({ 'teams._id': team.teamWithNoExternalTeam._id });
+			count.should.equal(0);
 		});
 
 		it('should reject if team has resources', async () => {


### PR DESCRIPTION
Fixes bug that where when a team is deleted, the team would only be removed from a single user's team list vs. all users.  Bug went unnoticed until additional test coverage was added.  Even then it only occasionally caused a test failure.  Updated test case to ensure it consistently caused error, than fixed.  Also cleaned up some unused parameters.