### PR TITLE
build: Add optional typescript compile check

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,10 @@
 		"sourceType": "module"
 	},
 
+  	"plugins": [
+	  	"jsdoc"
+	],
+
 	"extends": "eslint:recommended",
 	"rules": {
 		"arrow-parens": ["error", "always"],
@@ -42,7 +46,8 @@
 		"prefer-template": ["error"],
 		"template-curly-spacing": ["error"],
 		"rest-spread-spacing": ["error"],
-		"prefer-arrow-callback": ["error"]
+		"prefer-arrow-callback": ["error"],
+	  	"jsdoc/no-undefined-types": 1
 
 		//		"arrow-body-style": ["warn", "as-needed"],
 		//		"handle-callback-err": ["warn"],
@@ -51,6 +56,7 @@
 		//		"no-throw-literal": ["warn"],
 		//		"guard-for-in": ["warn"],
 		//		"no-shadow": ["warn"]
+
 	},
 
 	"globals": {

--- a/config/env/production.js
+++ b/config/env/production.js
@@ -1,7 +1,5 @@
 'use strict';
 
-const logstash = require('bunyan-logstash');
-
 module.exports = {
 
 	/**
@@ -47,16 +45,16 @@ module.exports = {
 				path: '/var/log/mean2/application.log',
 				period: '1d',
 				count: 1
-			},
-			// Logstash logger
-			{
-				type: 'raw',
-				level: 'info',
-				stream: logstash.createStream({
-					host: 'localhost',
-					port: 4561
-				})
 			}
+			// Logstash logger
+			// {
+			// 	type: 'raw',
+			// 	level: 'info',
+			// 	stream: logstash.createStream({
+			// 		host: 'localhost',
+			// 		port: 4561
+			// 	})
+			// }
 		],
 		audit: [
 			// Console logger (audit logger must be 'info' level)

--- a/package-lock.json
+++ b/package-lock.json
@@ -479,6 +479,15 @@
         "@types/node": "*"
       }
     },
+    "@types/engine.io": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/@types/engine.io/-/engine.io-3.1.5.tgz",
+      "integrity": "sha512-DLVpLEGTEZGBXOYoYoagHSxXkDHONc0fZouF2ayw7Q18aRu1Afwci+1CFKvPpouCUOVWP+dmCaAWpQjswe7kpg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/express": {
       "version": "4.16.1",
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.16.1.tgz",
@@ -504,6 +513,12 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@types/mime/-/mime-2.0.1.tgz",
       "integrity": "sha512-FwI9gX75FgVBJ7ywgnq/P7tw+/o1GUbtP0KzbtusLigAOgIgNISRK0ZPl4qertvXSIE8YbsVJueQ90cDt9YYyw==",
+      "dev": true
+    },
+    "@types/mocha": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-8.2.1.tgz",
+      "integrity": "sha512-NysN+bNqj6E0Hv4CTGWSlPzMW6vTKjDpOteycDkV4IWBsO+PU48JonrPzV9ODjiI2XrjmA05KInLgF5ivZ/YGQ==",
       "dev": true
     },
     "@types/node": {
@@ -547,6 +562,26 @@
       "requires": {
         "@types/express-serve-static-core": "*",
         "@types/mime": "*"
+      }
+    },
+    "@types/socket.io": {
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/@types/socket.io/-/socket.io-2.1.13.tgz",
+      "integrity": "sha512-JRgH3nCgsWel4OPANkhH8TelpXvacAJ9VeryjuqCDiaVDMpLysd6sbt0dr6Z15pqH3p2YpOT3T1C5vQ+O/7uyg==",
+      "dev": true,
+      "requires": {
+        "@types/engine.io": "*",
+        "@types/node": "*",
+        "@types/socket.io-parser": "*"
+      }
+    },
+    "@types/socket.io-parser": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@types/socket.io-parser/-/socket.io-parser-2.2.1.tgz",
+      "integrity": "sha512-+JNb+7N7tSINyXPxAJb62+NcpC1x/fPn7z818W4xeNCdPTp6VsO/X8fCsg6+ug4a56m1v9sEiTIIUKVupcHOFQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
       }
     },
     "JSONPath": {
@@ -1336,6 +1371,12 @@
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
       "optional": true
     },
+    "comment-parser": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.1.2.tgz",
+      "integrity": "sha512-AOdq0i8ghZudnYv8RUnHrhTgafUGs61Rdz9jemU5x2lnZwAWyOq7vySo626K59e1fVKH1xSRorJwPVRLSWOoAQ==",
+      "dev": true
+    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -1934,6 +1975,53 @@
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
           "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==",
           "dev": true
+        }
+      }
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "32.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-32.2.0.tgz",
+      "integrity": "sha512-ikeVeF3JVmzjcmGd04OZK0rXjgiw46TWtNX+OhyF2jQlw3w1CAU1vyAyLv8PZcIjp7WxP4N20Vg1CI9bp/52dw==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "1.1.2",
+        "debug": "^4.3.1",
+        "jsdoctypeparser": "^9.0.0",
+        "lodash": "^4.17.20",
+        "regextras": "^0.7.1",
+        "semver": "^7.3.4",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+          "dev": true,
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "lodash": {
+          "version": "4.17.21",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+          "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+          "dev": true
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "dev": true
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
         }
       }
     },
@@ -3512,6 +3600,12 @@
         "esprima": "^4.0.0"
       }
     },
+    "jsdoctypeparser": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz",
+      "integrity": "sha512-jrTA2jJIL6/DAEILBEh2/w9QxCuwmvNXIry39Ay/HVfhE3o2yVV0U44blYkqdHA/OKloJEqvJy0xU+GSdE2SIw==",
+      "dev": true
+    },
     "jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -3941,6 +4035,15 @@
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-1.0.1.tgz",
       "integrity": "sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==",
       "dev": true
+    },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "requires": {
+        "yallist": "^4.0.0"
+      }
     },
     "make-dir": {
       "version": "3.0.2",
@@ -5424,6 +5527,12 @@
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
       "dev": true
     },
+    "regextras": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.7.1.tgz",
+      "integrity": "sha512-9YXf6xtW+qzQ+hcMQXx95MOvfqXFgsKDZodX3qZB0x2n5Z94ioetIITsBtvJbiOyxa/6s9AtyweBLCdPmPko/w==",
+      "dev": true
+    },
     "registry-auth-token": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-4.1.1.tgz",
@@ -5934,6 +6043,28 @@
         }
       }
     },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+      "dev": true
+    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -6426,6 +6557,11 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "typescript": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.3.tgz",
+      "integrity": "sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw=="
+    },
     "uglify-js": {
       "version": "3.8.1",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.8.1.tgz",
@@ -6769,6 +6905,12 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w==",
+      "dev": true
+    },
+    "yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
     },
     "yaml": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "lint": "npm run lint:eslint",
     "lint:fix": "npm run lint:eslint:fix",
     "lint:eslint": "eslint \"./**/*.js\"",
-    "lint:eslint:fix": "eslint \"./**/*.js\" --fix"
+    "lint:eslint:fix": "eslint \"./**/*.js\" --fix",
+    "tsc:check": "./node_modules/typescript/bin/tsc --project tsconfig.json --noEmit"
   },
   "nyc": {
     "include": "src",
@@ -68,13 +69,17 @@
     "swagger-parser": "~8.0.4",
     "swagger-ui-express": "4.1.3",
     "through2": "2.0",
+    "typescript": "^4.2.3",
     "uuid": "3.3"
   },
   "devDependencies": {
     "@types/express": "4.16",
+    "@types/mocha": "^8.2.1",
     "@types/passport": "0.4",
     "@types/q": "1.5",
+    "@types/socket.io": "^2.1.13",
     "eslint": "^6.8.0",
+    "eslint-plugin-jsdoc": "^32.2.0",
     "husky": "^4.2.1",
     "lint-staged": "^10.0.7",
     "mocha": "^7.1.1",

--- a/src/app/common/csv-stream.service.js
+++ b/src/app/common/csv-stream.service.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const
+	streams = require('stream'),
 	through2 = require('through2'),
 	stringify = require('csv-stringify'),
 	jsonpath = require('JSONPath'),
@@ -14,14 +15,13 @@ const
  * Creates a stream that accepts objects as input and returns a serialized CSV file.
  * The objects in the stream can come directly from Mongo.
  *
- * @param {Array{Object}} columns An array defining the columns to output in the CSV, in order.
+ * @param {Array.<Object>} columns An array defining the columns to output in the CSV, in order.
  *   Each object must contain:
  *     - key: A JSONPath selector to get the value for this column from the object
  *     - title: The title to use in the CSV header for the column
  *     - callback: Optionally, a function to do further processing of the value.  It must accept a value
  *         and return a value.
- *
- * @returns {Stream} A stream that can be piped to the HTTP response.
+ * @returns {streams.Transform} A stream that can be piped to the HTTP response.
  */
 module.exports = (columns) => {
 

--- a/src/app/common/event/event-emitter.service.js
+++ b/src/app/common/event/event-emitter.service.js
@@ -6,7 +6,7 @@ const EventEmitter = require('events');
  * external messaging system (e.g, RabbitMQ, Kafka, etc.)
  * Only use this EventEmitter in single-instance installations or for dev purposes
  */
-const eventEmitter = new EventEmitter();
+const eventEmitter = new EventEmitter.EventEmitter();
 
 function getEventEmitter() {
 	return eventEmitter;

--- a/src/app/common/mongoose/getter.plugin.js
+++ b/src/app/common/mongoose/getter.plugin.js
@@ -1,0 +1,13 @@
+/**
+ * Mongoose Getter plugin
+ *
+ * configures schema to include getters in `toObject` and `toJSON`
+ *
+ * @param schema
+ */
+function getterPlugin(schema) {
+	schema.set('toObject', { getters: true });
+	schema.set('toJSON', { getters: true });
+}
+
+module.exports = getterPlugin;

--- a/src/app/common/sockets/base-socket.provider.js
+++ b/src/app/common/sockets/base-socket.provider.js
@@ -86,7 +86,7 @@ BaseSocket.prototype.getRequest = function() {
  * @param {Function} next A callback for the async handler.  It will be called with an error if the middleware
  *   callback function passes any message to the UI.
  *
- * @returns {{status: status, send: send}}
+ * @returns {{status: Function, send: Function, json: Function}}
  */
 BaseSocket.prototype.getResponse = function(next) {
 	function send(data) {
@@ -118,8 +118,8 @@ BaseSocket.prototype.getResponse = function(next) {
  * Applies a set of callbacks in series.  Each function should accept a request and response object and
  * a callback function, in the same format as the Express.js middleware.
  *
- * @param {Array{Function}} callbacks An array of middleware callbacks to execute.
- * @param {Function=} done Optionally, a function that will be called when all middleware has processed, either
+ * @param {Array.<Function>} callbacks - An array of middleware callbacks to execute.
+ * @param {Function} [done] - Optionally, a function that will be called when all middleware has processed, either
  *   with an error or without.
  *
  * @returns {Promise} A promise that will be resolved when all the middleware has run.  You can either

--- a/src/app/common/sockets/event-socket.provider.js
+++ b/src/app/common/sockets/event-socket.provider.js
@@ -2,7 +2,6 @@
 
 const
 	_ = require('lodash'),
-	nodeUtil = require('util'),
 
 	deps = require('../../../dependencies'),
 	config = deps.config,
@@ -15,162 +14,158 @@ const
 // If this is not null, ignore any messages that are older than this number of seconds.
 const ignoreOlderThan = config.socketio.ignoreOlderThan;
 
-function EventSocket(socketConfig, ...args) {
-	this._emitRateMs = socketConfig.emitRateMs < 0 ? 0 : (+socketConfig.emitRateMs || 0);
-	BaseSocket.apply(this, [socketConfig, ...args]);
-}
-
-nodeUtil.inherits(
-	EventSocket,
-	BaseSocket);
-
-EventSocket.prototype.name = 'EventSocket';
-
-/**
- * Handle socket disconnects by unsubscribing from events.
- */
-EventSocket.prototype.disconnect = function() {
-	logger.info('%s: Disconnected from client.', this.name);
-	this.unsubscribe(null);
-};
-
-/**
- * Handle socket errors by unsubscribing from events.
- */
-EventSocket.prototype.error = function(err) {
-	logger.error(err, '%s: Client connection error', this.name);
-	this.unsubscribe(null);
-};
-
-/**
- * Returns the name of the socket event that will be transmitted to the client.
- * This should be overridden by each implementing class.
- *
- * @returns {string} The event name to transmit through the socket for each payload.
- */
-EventSocket.prototype.getEmitType = function() {
-	return this._emitType || 'payload';
-};
-
-/**
- * Extracts a timestamp from the payload, which can be used for filtering messages.
- *
- * @param {Object} json The payload, parsed as JSON.
- * @returns {Number} Returns the timestamp of the payload as a Long.
- */
-EventSocket.prototype.getMessageTime = function(json) {
-	// Default to extracting time from json
-	if (null != json) {
-		const time = json.time;
-		logger.debug('%s: Extracted message time of %d', this.name, time);
-		return time;
+class EventSocket extends BaseSocket {
+	constructor(socketConfig) {
+		super(socketConfig);
+		this._emitType = null;
+		this._emitRateMs = socketConfig.emitRateMs < 0 ? 0 : (+socketConfig.emitRateMs || 0);
 	}
 
-	if (logger.debug()) { // is debug enabled?
-		logger.debug('%s: Unknown time for message: %s', this.name, JSON.stringify(json));
+	/**
+	 * Handle socket disconnects by unsubscribing from events.
+	 */
+	disconnect() {
+		logger.info('%s: Disconnected from client.', this.name);
+		this.unsubscribe(null);
 	}
 
-	return null;
-};
+	/**
+	 * Handle socket errors by unsubscribing from events.
+	 */
+	error(err) {
+		logger.error(err, '%s: Client connection error', this.name);
+		this.unsubscribe(null);
+	}
 
-/**
- * Filters a payload to determine whether it should be transmitted. This should be overridden by the
- * implementing class. It does not need to filter by date, as this is done automatically for all payloads.
- *
- * @param {Object} json The payload, parsed as JSON.
- * @return {boolean} False if the payload should be sent to the client, true if it should be ignored.
- */
-EventSocket.prototype.ignorePayload = function(json) {
-	// Ignore any payloads that are too old.
-	if (null != ignoreOlderThan) {
-		const now = Date.now();
-		const messageTime = this.getMessageTime(json);
-		if (null != messageTime) {
-			if (messageTime + (ignoreOlderThan * 1000) < now) {
-				logger.debug('%s: Message is too old: %d is more than %d seconds older than %d', this.name, messageTime, ignoreOlderThan, now);
-				return true;
-			}
+	/**
+	 * Returns the name of the socket event that will be transmitted to the client.
+	 * This should be overridden by each implementing class.
+	 *
+	 * @returns {string} The event name to transmit through the socket for each payload.
+	 */
+	getEmitType() {
+		return this._emitType || 'payload';
+	}
+
+	/**
+	 * Extracts a timestamp from the payload, which can be used for filtering messages.
+	 *
+	 * @param {Object} json The payload, parsed as JSON.
+	 * @returns {Number} Returns the timestamp of the payload as a Long.
+	 */
+	getMessageTime(json) {
+		// Default to extracting time from json
+		if (null != json) {
+			const time = json.time;
+			logger.debug('%s: Extracted message time of %d', this.name, time);
+			return time;
 		}
-	}
-	return false;
-};
 
-/**
- * Allows child sockets to customize the way messages are emitted, for instance to provide more advanced throttling.
- * Default implementation emits to the socket as usual.
- *
- * @param {string} emitType The emit type
- * @param {Object} msg The message to emit
- */
-EventSocket.prototype.emitMessage = function(emitType, msg) {
-	this.getSocket().emit(emitType, msg);
-};
+		if (logger.debug()) { // is debug enabled?
+			logger.debug('%s: Unknown time for message: %s', this.name, JSON.stringify(json));
+		}
 
-/**
- * Subscribe to an event.
- *
- * @return null if eventName is not set, true if successful
- */
-EventSocket.prototype.subscribe = function(eventName) {
-	// Ignore bad input data
-	if (null == eventName) {
 		return null;
 	}
 
-	// Simple throttling is done here, if enabled
-
-	if (this._emitRateMs > 0) {
-		this.emitterFunc = _.throttle(this.socketPayloadHandler, this._emitRateMs).bind(this, eventName);
-	} else {
-		this.emitterFunc = this.socketPayloadHandler.bind(this, eventName);
-	}
-	eventEmitter.getEventEmitter().on(eventName, this.emitterFunc);
-};
-
-/**
- * Unsubscribe from a topic.  If no topic is specified, unsubscribes from all topics consumed by this socket.
- *
- * @param {string} topic The topic to unsubscribe from (optional).
- */
-EventSocket.prototype.unsubscribe = function(eventName) {
-	if (typeof this.emitterFunc === 'function') {
-		eventEmitter.getEventEmitter().removeListener(eventName, this.emitterFunc);
-	}
-};
-
-EventSocket.prototype.socketPayloadHandler = function(eventName, message) {
-	// Gracefully handle empty messages by ignoring and logging
-	if (null == message) {
-		logger.warn('%s: Ignoring empty message %s', this.name, message);
-		return;
-	}
-
-	const self = this;
-	logger.debug('%s: Received Event Message for event %s', this.name, eventName);
-	try {
-		// Unwrap the payload
-		if (null != message) {
-
-			// Ignore any payloads that don't pass the filter check.
-			if (self.ignorePayload(message)) {
-				return;
+	/**
+	 * Filters a payload to determine whether it should be transmitted. This should be overridden by the
+	 * implementing class. It does not need to filter by date, as this is done automatically for all payloads.
+	 *
+	 * @param {Object} json The payload, parsed as JSON.
+	 * @return {boolean} False if the payload should be sent to the client, true if it should be ignored.
+	 */
+	ignorePayload(json) {
+		// Ignore any payloads that are too old.
+		if (null != ignoreOlderThan) {
+			const now = Date.now();
+			const messageTime = this.getMessageTime(json);
+			if (null != messageTime) {
+				if (messageTime + (ignoreOlderThan * 1000) < now) {
+					logger.debug('%s: Message is too old: %d is more than %d seconds older than %d', this.name, messageTime, ignoreOlderThan, now);
+					return true;
+				}
 			}
+		}
+		return false;
+	}
 
-			// The message can be either an object or a promise for an object
-			Promise.all([message]).then(([msg]) => {
-				if (null != msg) {
-					self.emitMessage(self.getEmitType(), msg);
-				}
-			}).catch(function(err) {
-				if (logger.debug()) {
-					logger.debug('Ignoring payload for user %s: %s', this.getUserId(), err);
-				}
-			});
+	/**
+	 * Allows child sockets to customize the way messages are emitted, for instance to provide more advanced throttling.
+	 * Default implementation emits to the socket as usual.
+	 *
+	 * @param {string} emitType The emit type
+	 * @param {Object} msg The message to emit
+	 */
+	emitMessage(emitType, msg) {
+		this.getSocket().emit(emitType, msg);
+	}
+
+	/**
+	 * Subscribe to an event.
+	 *
+	 * @return null if eventName is not set, true if successful
+	 */
+	subscribe(eventName) {
+		// Ignore bad input data
+		if (null == eventName) {
+			return null;
+		}
+
+		// Simple throttling is done here, if enabled
+
+		if (this._emitRateMs > 0) {
+			this.emitterFunc = _.throttle(this.socketPayloadHandler, this._emitRateMs).bind(this, eventName);
+		} else {
+			this.emitterFunc = this.socketPayloadHandler.bind(this, eventName);
+		}
+		eventEmitter.getEventEmitter().on(eventName, this.emitterFunc);
+	}
+
+	/**
+	 * Unsubscribe from a topic.  If no topic is specified, unsubscribes from all topics consumed by this socket.
+	 *
+	 * @param {string} eventName The topic to unsubscribe from (optional).
+	 */
+	unsubscribe(eventName) {
+		if (typeof this.emitterFunc === 'function') {
+			eventEmitter.getEventEmitter().removeListener(eventName, this.emitterFunc);
 		}
 	}
-	catch (e) {
-		logger.error({err: e, msg: message.value }, '%s: Error parsing payload body.', this.name);
+
+	socketPayloadHandler(eventName, message) {
+		// Gracefully handle empty messages by ignoring and logging
+		if (null == message) {
+			logger.warn('%s: Ignoring empty message %s', this.name, message);
+			return;
+		}
+
+		const self = this;
+		logger.debug('%s: Received Event Message for event %s', this.name, eventName);
+		try {
+			// Unwrap the payload
+			if (null != message) {
+
+				// Ignore any payloads that don't pass the filter check.
+				if (self.ignorePayload(message)) {
+					return;
+				}
+
+				// The message can be either an object or a promise for an object
+				Promise.all([message]).then(([msg]) => {
+					if (null != msg) {
+						self.emitMessage(self.getEmitType(), msg);
+					}
+				}).catch(function (err) {
+					if (logger.debug()) {
+						logger.debug('Ignoring payload for user %s: %s', this.getUserId(), err);
+					}
+				});
+			}
+		} catch (e) {
+			logger.error({err: e, msg: message.value}, '%s: Error parsing payload body.', this.name);
+		}
 	}
-};
+}
 
 module.exports = EventSocket;

--- a/src/app/common/util.service.js
+++ b/src/app/common/util.service.js
@@ -137,7 +137,7 @@ module.exports.toLowerCase = function (v){
  * Parse an input as a date. Handles various types
  * of inputs, such as Strings, Date objects, and Numbers.
  *
- * @param {date} The input representing a date / timestamp
+ * @param {(string | number | Date | Array | Function | Object)} date The input representing a date / timestamp
  * @returns The timestamp in milliseconds since the Unix epoch
  */
 module.exports.dateParse = function (date) {

--- a/src/app/core/access-checker/cache/cache-entry.model.js
+++ b/src/app/core/access-checker/cache/cache-entry.model.js
@@ -2,15 +2,15 @@
 
 const
 	mongoose = require('mongoose'),
+	getterPlugin = require('../../../common/mongoose/getter.plugin'),
 	pagingSearchPlugin = require('../../../common/mongoose/paging-search.plugin'),
 	deps = require('../../../../dependencies'),
-	util = deps.utilService,
-	GetterSchema = deps.schemaService.GetterSchema;
+	util = deps.utilService;
 
 /**
  * Schema Declaration
  */
-const CacheEntrySchema = new GetterSchema({
+const CacheEntrySchema = new mongoose.Schema({
 	// The external id of this entry
 	key: {
 		type: String,
@@ -33,6 +33,7 @@ const CacheEntrySchema = new GetterSchema({
 	}
 });
 
+CacheEntrySchema.plugin(getterPlugin);
 CacheEntrySchema.plugin(pagingSearchPlugin);
 
 
@@ -54,6 +55,9 @@ CacheEntrySchema.index({ key: 1 });
  */
 
 CacheEntrySchema.statics.fullCopy = function(entry) {
+	/**
+	 * @type {Object.<string, any>}
+	 */
 	let toReturn = null;
 
 	if(null != entry){

--- a/src/app/core/audit/audit.model.js
+++ b/src/app/core/audit/audit.model.js
@@ -2,16 +2,15 @@
 
 const
 	mongoose = require('mongoose'),
+	getterPlugin = require('../../common/mongoose/getter.plugin'),
 	pagingSearchPlugin = require('../../common/mongoose/paging-search.plugin'),
 	deps = require('../../../dependencies'),
-	util = deps.utilService,
-
-	GetterSchema = deps.schemaService.GetterSchema;
+	util = deps.utilService;
 
 /**
  * Schema Declaration
  */
-const AuditSchema = new GetterSchema({
+const AuditSchema = new mongoose.Schema({
 	created: {
 		type: Date,
 		default: Date.now,
@@ -35,6 +34,7 @@ const AuditSchema = new GetterSchema({
 	}
 });
 
+AuditSchema.plugin(getterPlugin);
 AuditSchema.plugin(pagingSearchPlugin);
 
 /**

--- a/src/app/core/email/providers/https-email.provider.js
+++ b/src/app/core/email/providers/https-email.provider.js
@@ -11,8 +11,11 @@ const
 let config = {};
 
 const generateOptions = () => {
+	/**
+	 * @type {https.AgentOptions & { headers: Object<string, string|number>, method?: string, agent?: https.Agent }}
+	 */
 	const options = {
-		hostname: config.hostname,
+		host: config.hostname,
 		port: config.port,
 		ca: config.ca,
 		cert: config.cert,

--- a/src/app/core/export/export-config.controller.js
+++ b/src/app/core/export/export-config.controller.js
@@ -51,7 +51,7 @@ exports.requestExport = (req, res) => {
  * @param {*} res
  * @param {string} filename the name of the exported file
  * @param {{ key: string, title: string, callback?: Function }[]} columns the columns to include in the exported CSV file
- * @param {[] | streams.Readable} data an array of objects containing data for rows, or an instance of readable
+ * @param {Array.<any>} data an array of objects containing data for rows, or an instance of readable
  */
 exports.exportCSV = (req, res, filename, columns, data) => {
 	if (null !== data) {
@@ -79,7 +79,7 @@ exports.exportCSV = (req, res, filename, columns, data) => {
  * @param {*} req
  * @param {*} res
  * @param {string} filename the name of the exported file
- * @param {streams.Readable | string} text the text or readable stream to export
+ * @param {string} text the text or readable stream to export
  */
 exports.exportPlaintext = (req, res, filename, text) => {
 	if (null !== text) {

--- a/src/app/core/export/export-config.model.js
+++ b/src/app/core/export/export-config.model.js
@@ -6,9 +6,9 @@ const _ = require('lodash'),
 	deps = require('../../../dependencies'),
 	utilService = deps.utilService,
 
-	GetterSchema = deps.schemaService.GetterSchema;
+	getterPlugin = require('../../common/mongoose/getter.plugin');
 
-const ExportConfigSchema = new GetterSchema({
+const ExportConfigSchema = new mongoose.Schema({
 	type: {
 		type: String,
 		trim: true,
@@ -29,6 +29,7 @@ const ExportConfigSchema = new GetterSchema({
 		required: 'Created date is required'
 	}
 });
+ExportConfigSchema.plugin(getterPlugin);
 
 ExportConfigSchema.statics.auditCopy = (exportConfig) => {
 	const toReturn = {};

--- a/src/app/core/feedback/feedback.model.js
+++ b/src/app/core/feedback/feedback.model.js
@@ -2,16 +2,15 @@
 
 const
 	mongoose = require('mongoose'),
+	getterPlugin = require('../../common/mongoose/getter.plugin'),
 	pagingSearchPlugin = require('../../common/mongoose/paging-search.plugin'),
 	deps = require('../../../dependencies'),
-	util = deps.utilService,
-
-	GetterSchema = deps.schemaService.GetterSchema;
+	util = deps.utilService;
 
 /**
  * Schema Declaration
  */
-const FeedbackSchema = new GetterSchema({
+const FeedbackSchema = new mongoose.Schema({
 	created: {
 		type: Date,
 		default: Date.now,
@@ -28,7 +27,7 @@ const FeedbackSchema = new GetterSchema({
 	browser: { type: String },
 	classification: { type: String }
 });
-
+FeedbackSchema.plugin(getterPlugin);
 FeedbackSchema.plugin(pagingSearchPlugin);
 
 /**

--- a/src/app/core/messages/message.model.js
+++ b/src/app/core/messages/message.model.js
@@ -4,19 +4,18 @@ const
 	_ = require('lodash'),
 	mongoose = require('mongoose'),
 
+	getterPlugin = require('../../common/mongoose/getter.plugin'),
 	pagingSearchPlugin = require('../../common/mongoose/paging-search.plugin'),
 	deps = require('../../../dependencies'),
 	dbs = deps.dbs,
 	config = deps.config,
-	util = deps.utilService,
-
-	GetterSchema = deps.schemaService.GetterSchema;
+	util = deps.utilService;
 
 /**
  * Message Schema
  */
 
-const MessageSchema = new GetterSchema({
+const MessageSchema = new mongoose.Schema({
 	title: {
 		type: String,
 		trim: true,
@@ -50,10 +49,10 @@ const MessageSchema = new GetterSchema({
 		ref: 'User'
 	}
 });
-
+MessageSchema.plugin(getterPlugin);
 MessageSchema.plugin(pagingSearchPlugin);
 
-const DismissedMessageSchema = new GetterSchema({
+const DismissedMessageSchema = new mongoose.Schema({
 	messageId: {
 		type: mongoose.Schema.ObjectId,
 		ref: 'Message'
@@ -68,6 +67,7 @@ const DismissedMessageSchema = new GetterSchema({
 		get: util.dateParse
 	}
 });
+DismissedMessageSchema.plugin(getterPlugin);
 
 /**
  * Index declarations

--- a/src/app/core/messages/message.socket.js
+++ b/src/app/core/messages/message.socket.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const
-	nodeUtil = require('util'),
 	path = require('path'),
 
 	deps = require('../../../dependencies'),
@@ -18,106 +17,103 @@ const
  * MessageSocket Socket Controller that overrides Base Socket Controller
  * methods to handle specifics of Messages
  */
-function MessageSocket(...args) {
-	this._emitType = `${emitName}:data`;
-	this._topicName = config.messages.topic;
-	this._subscriptionCount = 0;
-	socketProvider.apply(this, args);
-}
-
-nodeUtil.inherits(MessageSocket, socketProvider);
-
-MessageSocket.prototype.name = 'MessageSocket';
-
-/**
- * @override
- *
- */
-MessageSocket.prototype.getEmitMessageKey = () => {
-	return '';
-};
-
-/**
- * Returns the topic for a user ID.
- */
-MessageSocket.prototype.getTopic = function(userId) {
-	return this._topicName;
-};
-
-/**
- * Handle socket disconnects
- */
-MessageSocket.prototype.disconnect = function() {
-	logger.info('MessageSocket: Disconnected from client.');
-
-	this.unsubscribe(this.getTopic());
-
-};
-
-/**
- * Handle socket errors
- */
-MessageSocket.prototype.error = function(err) {
-	logger.error(err, 'MessageSocket: Client connection error');
-
-	this.unsubscribe(this.getTopic());
-};
-
-/**
- *
- */
-MessageSocket.prototype.handleSubscribe = function(payload) {
-	const self = this;
-
-	if(logger.debug()) {
-		logger.debug(`MessageSocket: ${emitName}:subscribe event with payload: ${JSON.stringify(payload)}`);
+class MessageSocket extends socketProvider {
+	constructor(...args) {
+		super(...args);
+		this._emitType = `${emitName}:data`;
+		this._topicName = config.messages.topic;
+		this._subscriptionCount = 0;
 	}
 
-	// Check that the user account has access
-	self.applyMiddleware([
-		users.hasAccess
-	]).then(() => {
-		// Subscribe to the user's message topic
-		const topic = self.getTopic();
-		self.subscribe(topic);
-		self._subscriptionCount++;
-	}).catch((err) => {
-		logger.warn(`Unauthorized access to notifications by inactive user ${self.getUserId()}: ${err}`);
-	});
-};
-
-/**
- *
- */
-MessageSocket.prototype.handleUnsubscribe = function(payload) {
-	if(logger.debug()) {
-		logger.debug(`MessageSocket: ${emitName}:unsubscribe event with payload: ${JSON.stringify(payload)}`);
+	/**
+	 * @override
+	 *
+	 */
+	getEmitMessageKey() {
+		return '';
 	}
 
-	const topic = this.getTopic();
-	this.unsubscribe(topic);
+	/**
+	 * Returns the topic for a user ID.
+	 */
+	getTopic(userId) {
+		return this._topicName;
+	}
 
-	this._subscriptionCount = Math.max(0, this._subscriptionCount - 1);
-	// If we are no longer listening for anything, unsubscribe
-	if (this._subscriptionCount === 0) {
+	/**
+	 * Handle socket disconnects
+	 */
+	disconnect() {
+		logger.info('MessageSocket: Disconnected from client.');
+
 		this.unsubscribe(this.getTopic());
 	}
-};
 
-/**
- *
- */
-MessageSocket.prototype.addListeners = function() {
-	const s = this.getSocket();
+	/**
+	 * Handle socket errors
+	 */
+	error(err) {
+		logger.error(err, 'MessageSocket: Client connection error');
 
-	if(typeof s.on === 'function') {
-		// Set up Subscribe events
-		s.on(`${emitName}:subscribe`, this.handleSubscribe.bind(this));
-
-		// Set up Unsubscribe events
-		s.on(`${emitName}:unsubscribe`, this.handleUnsubscribe.bind(this));
+		this.unsubscribe(this.getTopic());
 	}
-};
+
+	/**
+	 *
+	 */
+	handleSubscribe(payload) {
+		const self = this;
+
+		if(logger.debug()) {
+			logger.debug(`MessageSocket: ${emitName}:subscribe event with payload: ${JSON.stringify(payload)}`);
+		}
+
+		// Check that the user account has access
+		self.applyMiddleware([
+			users.hasAccess
+		]).then(() => {
+			// Subscribe to the user's message topic
+			const topic = self.getTopic();
+			self.subscribe(topic);
+			self._subscriptionCount++;
+		}).catch((err) => {
+			logger.warn(`Unauthorized access to notifications by inactive user ${self.getUserId()}: ${err}`);
+		});
+	}
+
+	/**
+	 *
+	 */
+	handleUnsubscribe(payload) {
+		if(logger.debug()) {
+			logger.debug(`MessageSocket: ${emitName}:unsubscribe event with payload: ${JSON.stringify(payload)}`);
+		}
+
+		const topic = this.getTopic();
+		this.unsubscribe(topic);
+
+		this._subscriptionCount = Math.max(0, this._subscriptionCount - 1);
+		// If we are no longer listening for anything, unsubscribe
+		if (this._subscriptionCount === 0) {
+			this.unsubscribe(this.getTopic());
+		}
+	}
+
+	/**
+	 *
+	 */
+	addListeners() {
+		const s = this.getSocket();
+
+		if(typeof s.on === 'function') {
+			// Set up Subscribe events
+			s.on(`${emitName}:subscribe`, this.handleSubscribe.bind(this));
+
+			// Set up Unsubscribe events
+			s.on(`${emitName}:unsubscribe`, this.handleUnsubscribe.bind(this));
+		}
+	}
+}
 
 socketIO.registerSocketListener(MessageSocket);
 

--- a/src/app/core/notifications/notification.socket.js
+++ b/src/app/core/notifications/notification.socket.js
@@ -2,7 +2,6 @@
 
 const
 	_ = require('lodash'),
-	nodeUtil = require('util'),
 	path = require('path'),
 
 	deps = require('../../../dependencies'),
@@ -19,118 +18,115 @@ const
  * NotificationSocket Socket Controller that overrides Base Socket Controller
  * methods to handle specifics of Notifications
  */
-function NotificationSocket(...args) {
-	this._emitType = `${emitName}:data`;
-	this._topicName = config.dispatcher ? config.dispatcher.notificationTopic : '';
-	this._subscriptionCount = 0;
-	socketProvider.apply(this, args);
-}
-
-nodeUtil.inherits(NotificationSocket, socketProvider);
-
-NotificationSocket.prototype.name = 'NotificationSocket';
-
-/**
- * @override
- *
- */
-NotificationSocket.prototype.getEmitNotificationKey = () => {
-	return '';
-};
-
-NotificationSocket.prototype.getEmitMessage = function(json, rawMessage, consumer) {
-	return {
-		value: json,
-		key: this.getEmitMessageKey(json, rawMessage, consumer)
-	};
-};
-//
-NotificationSocket.prototype.ignorePayload = function(json) {
-	// Ignore any payloads that do not match the current user.
-	return !json || !json.user || json.user.toString() !== this.getUserId().toString();
-};
-
-/**
- * Returns the topic for a user ID.
- */
-NotificationSocket.prototype.getTopic = function(userId) {
-	return this._topicName;
-};
-
-/**
- * Handle socket disconnects
- */
-NotificationSocket.prototype.disconnect = function() {
-	logger.info('NotificationSocket: Disconnected from client.');
-
-	this.unsubscribe(this.getTopic());
-
-};
-
-/**
- * Handle socket errors
- */
-NotificationSocket.prototype.error = function(err) {
-	logger.error(err, 'NotificationSocket: Client connection error');
-
-	this.unsubscribe(this.getTopic());
-};
-
-/**
- *
- */
-NotificationSocket.prototype.handleSubscribe = function(payload) {
-	const self = this;
-
-	if(logger.debug()) {
-		logger.debug(`NotificationSocket: ${emitName}:subscribe event with payload: ${JSON.stringify(payload)}`);
+class NotificationSocket extends socketProvider {
+	constructor(...args) {
+		super(...args);
+		this._emitType = `${emitName}:data`;
+		this._topicName = config.dispatcher ? config.dispatcher.notificationTopic : '';
+		this._subscriptionCount = 0;
 	}
 
-	// Check that the user account has access
-	self.applyMiddleware([
-		users.hasAccess
-	]).then(() => {
-		// Subscribe to the user's notification topic
-		const topic = self.getTopic();
-		self.subscribe(topic);
-		self._subscriptionCount++;
-	}).catch((err) => {
-		logger.warn(`Unauthorized access to notifications by inactive user ${self.getUserId()}: ${err}`);
-	});
-};
-
-/**
- *
- */
-NotificationSocket.prototype.handleUnsubscribe = function(payload) {
-	if(logger.debug()) {
-		logger.debug(`NotificationSocket: ${emitName}:unsubscribe event with payload: ${JSON.stringify(payload)}`);
+	/**
+	 * @override
+	 *
+	 */
+	getEmitNotificationKey() {
+		return '';
 	}
 
-	const topic = this.getTopic();
-	this.unsubscribe(topic);
+	getEmitMessage(json, rawMessage, consumer) {
+		return {
+			value: json,
+			key: this.getEmitMessageKey(json, rawMessage, consumer)
+		};
+	}
 
-	this._subscriptionCount = Math.max(0, this._subscriptionCount - 1);
-	// If we are no longer listening for anything, unsubscribe
-	if (this._subscriptionCount === 0) {
+	ignorePayload(json) {
+		// Ignore any payloads that do not match the current user.
+		return !json || !json.user || json.user.toString() !== this.getUserId().toString();
+	}
+
+	/**
+	 * Returns the topic for a user ID.
+	 */
+	getTopic(userId) {
+		return this._topicName;
+	}
+
+	/**
+	 * Handle socket disconnects
+	 */
+	disconnect() {
+		logger.info('NotificationSocket: Disconnected from client.');
+
 		this.unsubscribe(this.getTopic());
 	}
-};
 
-/**
- *
- */
-NotificationSocket.prototype.addListeners = function() {
-	const s = this.getSocket();
+	/**
+	 * Handle socket errors
+	 */
+	error(err) {
+		logger.error(err, 'NotificationSocket: Client connection error');
 
-	if(typeof s.on === 'function') {
-		// Set up Subscribe events
-		s.on(`${emitName}:subscribe`, this.handleSubscribe.bind(this));
-
-		// Set up Unsubscribe events
-		s.on(`${emitName}:unsubscribe`, this.handleUnsubscribe.bind(this));
+		this.unsubscribe(this.getTopic());
 	}
-};
+
+	/**
+	 *
+	 */
+	handleSubscribe(payload) {
+		const self = this;
+
+		if(logger.debug()) {
+			logger.debug(`NotificationSocket: ${emitName}:subscribe event with payload: ${JSON.stringify(payload)}`);
+		}
+
+		// Check that the user account has access
+		self.applyMiddleware([
+			users.hasAccess
+		]).then(() => {
+			// Subscribe to the user's notification topic
+			const topic = self.getTopic();
+			self.subscribe(topic);
+			self._subscriptionCount++;
+		}).catch((err) => {
+			logger.warn(`Unauthorized access to notifications by inactive user ${self.getUserId()}: ${err}`);
+		});
+	}
+
+	/**
+	 *
+	 */
+	handleUnsubscribe(payload) {
+		if(logger.debug()) {
+			logger.debug(`NotificationSocket: ${emitName}:unsubscribe event with payload: ${JSON.stringify(payload)}`);
+		}
+
+		const topic = this.getTopic();
+		this.unsubscribe(topic);
+
+		this._subscriptionCount = Math.max(0, this._subscriptionCount - 1);
+		// If we are no longer listening for anything, unsubscribe
+		if (this._subscriptionCount === 0) {
+			this.unsubscribe(this.getTopic());
+		}
+	}
+
+	/**
+	 *
+	 */
+	addListeners() {
+		const s = this.getSocket();
+
+		if(typeof s.on === 'function') {
+			// Set up Subscribe events
+			s.on(`${emitName}:subscribe`, this.handleSubscribe.bind(this));
+
+			// Set up Unsubscribe events
+			s.on(`${emitName}:unsubscribe`, this.handleUnsubscribe.bind(this));
+		}
+	}
+}
 
 if (config.dispatcher && (!_.has(config.dispatcher, 'enabled') || config.dispatcher.enabled)) {
 	socketIO.registerSocketListener(NotificationSocket);

--- a/src/app/core/resources/resource.model.js
+++ b/src/app/core/resources/resource.model.js
@@ -7,13 +7,13 @@ const
 
 	deps = require('../../../dependencies'),
 	util = deps.utilService,
-	GetterSchema = deps.schemaService.GetterSchema;
+	getterPlugin = require('../../common/mongoose/getter.plugin');
 
 /**
  * Owner Schema
  */
 
-const OwnerSchema = new GetterSchema({
+const OwnerSchema = new mongoose.Schema({
 	type: {
 		type: String,
 		default: 'team',
@@ -29,6 +29,8 @@ const OwnerSchema = new GetterSchema({
 		trim: true
 	}
 });
+
+OwnerSchema.plugin(getterPlugin);
 
 OwnerSchema.index({ name: 1 });
 
@@ -93,9 +95,13 @@ ResourceSchema.index({ title_lowercase: 'text', description: 'text' });
 /**
  * Lifecycle hooks
  */
-
 ResourceSchema.pre('save', function(next){
-	this.title_lowercase = this.title;
+	/**
+	 * @type {(mongoose.Schema.methods|mongoose.Model)}
+	 */
+	const user = this;
+
+	user.title_lowercase = user.title;
 	next();
 });
 
@@ -110,6 +116,9 @@ ResourceSchema.pre('save', function(next){
 
 // Create a filtered copy for auditing
 ResourceSchema.statics.auditCopy = function(src) {
+	/**
+	 * @type {Object.<string, any>}
+	 */
 	const toReturn = {};
 	src = src || {};
 
@@ -124,6 +133,9 @@ ResourceSchema.statics.auditCopy = function(src) {
 };
 
 ResourceSchema.statics.auditUpdateCopy = function(src) {
+	/**
+	 * @type {Object.<string, any>}
+	 */
 	const toReturn = {};
 	src = src || {};
 

--- a/src/app/core/teams/team.model.js
+++ b/src/app/core/teams/team.model.js
@@ -4,11 +4,11 @@ const
 	_ = require('lodash'),
 	mongoose = require('mongoose'),
 
+	getterPlugin  = require('../../common/mongoose/getter.plugin'),
 	pagingSearchPlugin = require('../../common/mongoose/paging-search.plugin'),
 	deps = require('../../../dependencies'),
 	dbs = deps.dbs,
 	util = deps.utilService,
-	GetterSchema = deps.schemaService.GetterSchema,
 
 	UserModel = require('../user/user.model'),
 	UserSchema = UserModel.schema;
@@ -30,7 +30,7 @@ const
  *         role:
  *           type: string
  */
-const TeamRoleSchema = new GetterSchema({
+const TeamRoleSchema = new mongoose.Schema({
 	_id: {
 		type: mongoose.Schema.ObjectId,
 		ref: 'Team'
@@ -42,6 +42,7 @@ const TeamRoleSchema = new GetterSchema({
 		enum: [ 'admin', 'editor', 'member', 'requester' ]
 	}
 });
+TeamRoleSchema.plugin(getterPlugin);
 
 UserSchema.add({
 	teams: {
@@ -49,7 +50,7 @@ UserSchema.add({
 	}
 });
 
-const TeamSchema = new GetterSchema({
+const TeamSchema = new mongoose.Schema({
 	name: {
 		type: String,
 		trim: true,
@@ -93,7 +94,7 @@ const TeamSchema = new GetterSchema({
 		}]
 	}
 });
-
+TeamSchema.plugin(getterPlugin);
 TeamSchema.plugin(pagingSearchPlugin);
 
 

--- a/src/app/core/teams/teams.controller.spec.js
+++ b/src/app/core/teams/teams.controller.spec.js
@@ -18,9 +18,10 @@ describe('Teams Controller:', () => {
 		sandbox = sinon.createSandbox();
 		res = {
 			json: sinon.spy(),
-			end: sinon.spy()
+			end: sinon.spy(),
+			status: sinon.stub()
 		};
-		res.status = sinon.stub().returns(res);
+		res.status.returns(res);
 	});
 
 	afterEach(() => {

--- a/src/app/core/teams/teams.service.js
+++ b/src/app/core/teams/teams.service.js
@@ -329,7 +329,7 @@ const searchTeams = async (queryParams, query, search, user) => {
 	const offset = page * limit;
 
 	// If user is not an admin, constrain the results to the user's teams
-	if (!userAuthService.hasRoles(user, ['admin'], config.auth)) {
+	if (!userAuthService.hasRoles(user, ['admin'])) {
 		let teamIds = await getMemberTeamIds(user);
 
 		// If the query already has a filter by team, take the intersection
@@ -554,6 +554,9 @@ const getImplicitTeamIds = (user, ...roles) => {
 		user = user.toObject();
 	}
 
+	/**
+	 * @type {any}
+	 */
 	const query = {$and: [{implicitMembers: true}]};
 	if (strategy === 'roles' && user.externalRoles && user.externalRoles.length > 0) {
 		query.$and.push({

--- a/src/app/core/user/admin/user-admin.controller.js
+++ b/src/app/core/user/admin/user-admin.controller.js
@@ -126,7 +126,7 @@ exports.adminSearchUsers = async (req, res) => {
 		const results = await userService.searchUsers(req.query, query, search);
 		results.elements = results.elements.map((user) => {
 			const userCopy = User.fullCopy(user);
-			userAuthorizationService.updateRoles(userCopy, config.auth);
+			userAuthorizationService.updateRoles(userCopy);
 			return userCopy;
 		});
 		res.status(200).json(results);

--- a/src/app/core/user/admin/user-admin.controller.spec.js
+++ b/src/app/core/user/admin/user-admin.controller.spec.js
@@ -36,9 +36,10 @@ describe('User Admin Controller:', () => {
 	beforeEach(() => {
 		sandbox = sinon.createSandbox();
 		res = {
-			json: sinon.spy()
+			json: sinon.spy(),
+			status: sinon.stub()
 		};
-		res.status = sinon.stub().returns(res);
+		res.status.returns(res);
 	});
 
 	afterEach(() => {

--- a/src/app/core/user/auth/user-authentication.controller.js
+++ b/src/app/core/user/auth/user-authentication.controller.js
@@ -23,7 +23,7 @@ const deps = require('../../../../dependencies'),
 async function login(user, req, res) {
 	try {
 		const result = await userAuthService.login(user, req);
-		userAuthorizationService.updateRoles(result, config.auth);
+		userAuthorizationService.updateRoles(result);
 		res.status(200).json(result);
 	} catch(err) {
 		util.handleErrorResponse(res, err);
@@ -34,7 +34,7 @@ async function login(user, req, res) {
 async function authenticateAndLogin(req, res, next) {
 	try {
 		const result = await userAuthService.authenticateAndLogin(req, res, next);
-		userAuthorizationService.updateRoles(result, config.auth);
+		userAuthorizationService.updateRoles(result);
 		res.status(200).json(result);
 	} catch (err) {
 		util.handleErrorResponse(res, err);

--- a/src/app/core/user/eua/eua.controller.spec.js
+++ b/src/app/core/user/eua/eua.controller.spec.js
@@ -17,9 +17,10 @@ describe('EUA Controller:', () => {
 	beforeEach(() => {
 		sandbox = sinon.createSandbox();
 		res = {
-			json: sinon.spy()
+			json: sinon.spy(),
+			status: sinon.stub()
 		};
-		res.status = sinon.stub().returns(res);
+		res.status.returns(res);
 	});
 
 	afterEach(() => {

--- a/src/app/core/user/eua/eua.model.js
+++ b/src/app/core/user/eua/eua.model.js
@@ -2,15 +2,15 @@
 
 const
 	mongoose = require('mongoose'),
+	getterPlugin = require('../../../common/mongoose/getter.plugin'),
 	pagingSearchPlugin = require('../../../common/mongoose/paging-search.plugin'),
 	deps = require('../../../../dependencies'),
-	util = deps.utilService,
-	GetterSchema = deps.schemaService.GetterSchema;
+	util = deps.utilService;
 
 /**
  * User Schema
  */
-const UserAgreementSchema = new GetterSchema({
+const UserAgreementSchema = new mongoose.Schema({
 	title: {
 		type: String,
 		trim: true,
@@ -37,7 +37,7 @@ const UserAgreementSchema = new GetterSchema({
 		get: util.dateParse
 	}
 });
-
+UserAgreementSchema.plugin(getterPlugin);
 UserAgreementSchema.plugin(pagingSearchPlugin);
 
 

--- a/src/app/core/user/inactive/inactive-user-email.service.js
+++ b/src/app/core/user/inactive/inactive-user-email.service.js
@@ -86,7 +86,7 @@ module.exports.run = function(serviceConfig) {
 
 	return Promise.all([deactivatePromise, inactivityPromise]).then((data) => {
 		logger.debug('Both promises have resolved', data);
-	}).fail((err) => {
+	}).catch((err) => {
 		logger.error(`Failed scheduled run to deactivate inactive users. Error=${JSON.stringify(err)}`);
 		return Promise.reject(err);
 	});

--- a/src/app/core/user/preferences/preference-cleanup.service.js
+++ b/src/app/core/user/preferences/preference-cleanup.service.js
@@ -12,7 +12,6 @@ const
 
 /**
  * Query for multiple documents by ID and get results as a map from id -> result.
- * @param schema
  * @param ids
  * @param fieldsToReturn Optional array of fields to include in results. If empty will include all fields.
  * @param lean If true, will return as plain javascript objects instead of mongoose docs

--- a/src/app/core/user/profile/user-profile.controller.js
+++ b/src/app/core/user/profile/user-profile.controller.js
@@ -36,7 +36,7 @@ exports.getCurrentUser = async (req, res) => {
 
 	const userCopy = User.fullCopy(user);
 
-	userAuthorizationService.updateRoles(userCopy, config.auth);
+	userAuthorizationService.updateRoles(userCopy);
 
 	await teamService.updateTeams(userCopy);
 

--- a/src/app/core/user/profile/user-profile.controller.spec.js
+++ b/src/app/core/user/profile/user-profile.controller.spec.js
@@ -24,9 +24,10 @@ describe('User Profile Controller:', () => {
 	beforeEach(() => {
 		sandbox = sinon.createSandbox();
 		res = {
-			json: sinon.spy()
+			json: sinon.spy(),
+			status: sinon.stub()
 		};
-		res.status = sinon.stub().returns(res);
+		res.status.returns(res);
 	});
 
 	afterEach(() => {
@@ -451,7 +452,7 @@ describe('User Profile Controller:', () => {
 
 			let error;
 			try {
-				await userProfileController.hasEdit(req, res);
+				await userProfileController.hasEdit(req);
 			} catch (err) {
 				error = err;
 			}
@@ -471,7 +472,7 @@ describe('User Profile Controller:', () => {
 
 			let error;
 			try {
-				await userProfileController.hasEdit(req, res);
+				await userProfileController.hasEdit(req);
 			} catch (err) {
 				error = err;
 			}

--- a/src/app/core/user/user.model.js
+++ b/src/app/core/user/user.model.js
@@ -9,8 +9,8 @@ const
 	deps = require('../../../dependencies'),
 	config = deps.config,
 	util = deps.utilService,
-	pagingSearchPlugin = require('../../common/mongoose/paging-search.plugin'),
-	GetterSchema = deps.schemaService.GetterSchema;
+	getterPlugin = require('../../common/mongoose/getter.plugin'),
+	pagingSearchPlugin = require('../../common/mongoose/paging-search.plugin');
 
 /**
  * Validation
@@ -117,7 +117,7 @@ const roleSchemaDef = {
  *         preferences:
  *           type: object
  */
-const UserSchema = new GetterSchema({
+const UserSchema = new mongoose.Schema({
 	name: {
 		type: String,
 		trim: true,
@@ -227,6 +227,7 @@ const UserSchema = new GetterSchema({
 		type: {}
 	}
 });
+UserSchema.plugin(getterPlugin);
 UserSchema.plugin(uniqueValidator);
 UserSchema.plugin(pagingSearchPlugin);
 
@@ -244,6 +245,9 @@ UserSchema.index({ name: 'text', email: 'text', username: 'text' });
 
 // Process the password
 UserSchema.pre('save', function(next) {
+	/**
+	 * @type {(mongoose.Schema.methods|mongoose.Model)}
+	 */
 	const user = this;
 
 	// If the password is modified and it is valid, then re- salt/hash it
@@ -253,7 +257,7 @@ UserSchema.pre('save', function(next) {
 	}
 
 	// Remember whether the document was new, for the post-save hook
-	this.wasNew = this.isNew;
+	this.wasNew = user.isNew;
 
 	next();
 });
@@ -301,6 +305,9 @@ UserSchema.statics.hasRoles = function(user, roles){
 
 // Filtered Copy of a User (public)
 UserSchema.statics.filteredCopy = function(user) {
+	/**
+	 * @type {Object.<string, any>}
+	 */
 	let toReturn = null;
 
 	if(null != user){

--- a/src/app/core/user/user.service.spec.js
+++ b/src/app/core/user/user.service.spec.js
@@ -6,7 +6,6 @@ const
 	userService = require('./user.service'),
 	deps = require('../../../dependencies'),
 	User = deps.dbs.admin.model('User');
-
 /**
  * Helpers
  */

--- a/src/config.js
+++ b/src/config.js
@@ -3,7 +3,7 @@
 
 const
 	_ = require('lodash'),
-	chalk = require('chalk'),
+	chalk = require('chalk').default,
 	glob = require('glob'),
 	path = require('path');
 

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -22,5 +22,6 @@ module.exports.emailService        = require('./app/core/email/email.service');
 // Common Services
 module.exports.errorService  = require('./app/common/errors.service');
 module.exports.utilService   = require('./app/common/util.service');
+module.exports.schemaService = require('./app/common/schema.service');
 module.exports.csvStream     = require('./app/common/csv-stream.service');
 module.exports.delayedStream = require('./app/common/delayed-stream.service');

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -22,6 +22,5 @@ module.exports.emailService        = require('./app/core/email/email.service');
 // Common Services
 module.exports.errorService  = require('./app/common/errors.service');
 module.exports.utilService   = require('./app/common/util.service');
-module.exports.schemaService = require('./app/common/schema.service');
 module.exports.csvStream     = require('./app/common/csv-stream.service');
 module.exports.delayedStream = require('./app/common/delayed-stream.service');

--- a/src/lib/socket.io.js
+++ b/src/lib/socket.io.js
@@ -60,14 +60,15 @@ module.exports = (app, db) => {
 				socket.request.session = session;
 
 				// Use Passport to populate the user details
+				// @ts-ignore
 				passport.initialize()(socket.request, {}, () => {
 					passport.session()(socket.request, {}, () => {
 						if (socket.request.user) {
 							logger.debug('SocketIO: New authenticated user: %s', socket.request.user.username);
-							return next(null, true);
+							return next(null);
 						}
 						logger.info('SocketIO: Unauthenticated user attempting to connect.');
-						return next(new Error('User is not authenticated'), false);
+						return next(new Error('User is not authenticated'));
 					});
 				});
 			});
@@ -77,7 +78,7 @@ module.exports = (app, db) => {
 	// Add an event listener to the 'connection' event
 	io.on('connection', onConnect);
 
-	return server;
+	return app;
 };
 
 /*

--- a/src/lib/strategies/proxy-pki.js
+++ b/src/lib/strategies/proxy-pki.js
@@ -4,7 +4,6 @@ const
 	_ = require('lodash'),
 	mongoose = require('mongoose'),
 	passport = require('passport'),
-	util = require('util'),
 
 	deps = require('../../dependencies'),
 	dbs = deps.dbs,
@@ -17,26 +16,24 @@ const
 	TeamMember = dbs.admin.model('TeamUser'),
 	User = mongoose.model('User');
 
-function ProxyPkiStrategy(options, verify) {
-	if (typeof options === 'function') {
-		verify = options;
-		options = {};
+class ProxyPkiStrategy extends passport.Strategy {
+	constructor(options, verify) {
+		if (typeof options === 'function') {
+			verify = options;
+			options = {};
+		}
+
+		if (!verify) throw new Error('Proxy Pki Strategy requires a verify function');
+
+		super();
+		passport.Strategy.call(this);
+
+		this.name = 'proxy-pki';
+		this._verify = verify;
+		this._primaryUserHeader = options.primaryUserHeader || 'x-ssl-client-s-dn';
+		this._proxiedUserHeader = options.proxiedUserHeader || 'x-proxied-user-dn';
 	}
-
-	if (!verify) throw new Error('Proxy Pki Strategy requires a verify function');
-
-	passport.Strategy.call(this);
-
-	this.name = 'proxy-pki';
-	this._verify = verify;
-	this._primaryUserHeader = options.primaryUserHeader || 'x-ssl-client-s-dn';
-	this._proxiedUserHeader = options.proxiedUserHeader || 'x-proxied-user-dn';
 }
-
-/**
- * Inherit from `passport.Strategy`.
- */
-util.inherits(ProxyPkiStrategy, passport.Strategy);
 
 /**
  * Authenticate request based on the contents of the dn header value.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,80 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    // "incremental": true,                         /* Enable incremental compilation */
+    "target": "es2019",                                /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "commonjs",                           /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    // "lib": [],                                   /* Specify library files to be included in the compilation. */
+    "allowJs": true,                                /* Allow javascript files to be compiled. */
+    "checkJs": true,                                /* Report errors in .js files. */
+    // "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
+    // "declaration": true,                         /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    // "sourceMap": true,                           /* Generates corresponding '.map' file. */
+    // "outFile": "./",                             /* Concatenate and emit output to single file. */
+    // "outDir": "./",                              /* Redirect output structure to the directory. */
+    // "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                           /* Enable project compilation */
+    // "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
+    // "removeComments": true,                      /* Do not emit comments to output. */
+    // "noEmit": true,                              /* Do not emit outputs. */
+    // "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,                  /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    // "strict": true,                                 /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                       /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,                    /* Enable strict null checks. */
+    // "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,                 /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,        /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                      /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                        /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                      /* Report errors on unused locals. */
+    // "noUnusedParameters": true,                  /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,                   /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
+    // "noUncheckedIndexedAccess": true,            /* Include 'undefined' in index signature results */
+    // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",                  /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
+    "typeRoots": [                                  /* List of folders to include type definitions from. */
+      "node_modules/@types"
+    ],
+    // "types": [],                                 /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                        /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                            /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                               /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,                     /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                       /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,              /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,               /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "skipLibCheck": true,                           /* Skip type checking of declaration files. */
+    "forceConsistentCasingInFileNames": true,       /* Disallow inconsistently-cased references to the same file. */
+    "resolveJsonModule": true
+  },
+  "exclude": ["node_modules", "coverage","dist"],
+  "include": [
+    "./src",
+    "./config"
+  ]
+}


### PR DESCRIPTION
The typescript compiler can be run against javascript code and check for various potential issues based on its ability to infer typings.  This can also be supplemented with using JSDoc comments to specify types beyond what can be inferred by the typescript compiler.

Added npm script to execute compiler.  Eventually we may want to run as part of build/ci, but for now leaving it as optional to testing purposes.