### PR TITLE
Feat/feedback update

### DIFF
--- a/src/app/core/feedback/feedback.controller.js
+++ b/src/app/core/feedback/feedback.controller.js
@@ -35,6 +35,10 @@ module.exports.submitFeedback = async function(req, res) {
 
 		res.status(200).json(feedback);
 	} catch (err) {
+		logger.error(
+			{ err: err, req: req },
+			'Error submitting feedback'
+		);
 		utilService.handleErrorResponse(res, err);
 	}
 };

--- a/src/app/core/feedback/feedback.controller.js
+++ b/src/app/core/feedback/feedback.controller.js
@@ -167,11 +167,13 @@ module.exports.updateFeedbackAssignee = async (req, res) => {
 			req.headers
 		);
 
+		const updateFeedbackAssigneePromise = feedbackService.updateFeedbackAssignee(
+			req.params.feedbackId,
+			req.body.assignee
+		);
+
 		res.status(200).json(
-			await feedbackService.updateFeedbackAssignee(
-				req.params.feedbackId,
-				req.body.assignee
-			)
+			await updateFeedbackAssigneePromise
 		);
 	} catch (err) {
 		logger.error(
@@ -197,11 +199,13 @@ module.exports.updateFeedbackStatus = async (req, res) => {
 			req.headers
 		);
 
+		const updateFeedbackStatusPromise = feedbackService.updateFeedbackStatus(
+			req.params.feedbackId,
+			req.body.status
+		);
+
 		res.status(200).json(
-			await feedbackService.updateFeedbackStatus(
-				req.params.feedbackId,
-				req.body.status
-			)
+			await updateFeedbackStatusPromise
 		);
 	} catch (err) {
 		logger.error({ err: err, req: req }, 'Error updating feedback status');

--- a/src/app/core/feedback/feedback.controller.js
+++ b/src/app/core/feedback/feedback.controller.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const deps = require('../../../dependencies'),
+const
+	deps = require('../../../dependencies'),
 	dbs = deps.dbs,
 	config = deps.config,
 	logger = deps.logger,

--- a/src/app/core/feedback/feedback.controller.js
+++ b/src/app/core/feedback/feedback.controller.js
@@ -224,7 +224,6 @@ module.exports.feedbackById = async (req, res, next, id) => {
 		req.feedback = await feedbackService.readFeedback(id, populate);
 		return next();
 	} catch (err) {
-		logger.error({ err: err, req: req }, 'Error getting feedback');
 		utilService.handleErrorResponse(res, err);
 	}
 };

--- a/src/app/core/feedback/feedback.controller.js
+++ b/src/app/core/feedback/feedback.controller.js
@@ -141,8 +141,8 @@ module.exports.search = async (req, res) => {
 			req.query,
 			query
 		);
-
-		res.status(200).json(await searchPromise);
+		const results = await searchPromise;
+		res.status(200).json(results);
 	} catch (err) {
 		logger.error(
 			{ err: err, req: req },
@@ -171,8 +171,8 @@ module.exports.updateFeedbackAssignee = async (req, res) => {
 			req.feedback,
 			req.body.assignee
 		);
-
-		res.status(200).json(await updateFeedbackAssigneePromise);
+		const updatedFeedback = await updateFeedbackAssigneePromise;
+		res.status(200).json(updatedFeedback);
 	} catch (err) {
 		logger.error(
 			{ err: err, req: req },
@@ -201,8 +201,8 @@ module.exports.updateFeedbackStatus = async (req, res) => {
 			req.feedback,
 			req.body.status
 		);
-
-		res.status(200).json(await updateFeedbackStatusPromise);
+		const updatedFeedback = await updateFeedbackStatusPromise;
+		res.status(200).json(updatedFeedback);
 	} catch (err) {
 		logger.error({ err: err, req: req }, 'Error updating feedback status');
 		utilService.handleErrorResponse(res, err);
@@ -222,6 +222,9 @@ module.exports.feedbackById = async (req, res, next, id) => {
 
 	try {
 		req.feedback = await feedbackService.readFeedback(id, populate);
+		if (null == req.feedback) {
+			return utilService.handleErrorResponse(res, { status: 404, type: 'not-found', message: 'Could not find feedback' });
+		}
 		return next();
 	} catch (err) {
 		utilService.handleErrorResponse(res, err);

--- a/src/app/core/feedback/feedback.controller.js
+++ b/src/app/core/feedback/feedback.controller.js
@@ -168,13 +168,11 @@ module.exports.updateFeedbackAssignee = async (req, res) => {
 		);
 
 		const updateFeedbackAssigneePromise = feedbackService.updateFeedbackAssignee(
-			req.params.feedbackId,
+			req.feedback,
 			req.body.assignee
 		);
 
-		res.status(200).json(
-			await updateFeedbackAssigneePromise
-		);
+		res.status(200).json(await updateFeedbackAssigneePromise);
 	} catch (err) {
 		logger.error(
 			{ err: err, req: req },
@@ -200,15 +198,33 @@ module.exports.updateFeedbackStatus = async (req, res) => {
 		);
 
 		const updateFeedbackStatusPromise = feedbackService.updateFeedbackStatus(
-			req.params.feedbackId,
+			req.feedback,
 			req.body.status
 		);
 
-		res.status(200).json(
-			await updateFeedbackStatusPromise
-		);
+		res.status(200).json(await updateFeedbackStatusPromise);
 	} catch (err) {
 		logger.error({ err: err, req: req }, 'Error updating feedback status');
+		utilService.handleErrorResponse(res, err);
+	}
+};
+
+/**
+ * Feedback middleware
+ */
+module.exports.feedbackById = async (req, res, next, id) => {
+	const populate = [
+		{
+			path: 'creator',
+			select: ['username', 'organization', 'name', 'email']
+		}
+	];
+
+	try {
+		req.feedback = await feedbackService.readFeedback(id, populate);
+		return next();
+	} catch (err) {
+		logger.error({ err: err, req: req }, 'Error getting feedback');
 		utilService.handleErrorResponse(res, err);
 	}
 };

--- a/src/app/core/feedback/feedback.controller.spec.js
+++ b/src/app/core/feedback/feedback.controller.spec.js
@@ -6,12 +6,10 @@ const request = require('supertest'),
 	bodyParser = require('body-parser'),
 	mock = require('mock-require'),
 	deps = require('../../../dependencies'),
-
 	Feedback = deps.dbs.admin.model('Feedback'),
 	User = deps.dbs.admin.model('User');
 
 describe('Feedback Controller', () => {
-
 	let app;
 	const router = express.Router();
 
@@ -62,8 +60,7 @@ describe('Feedback Controller', () => {
 	const setAdmin = (isAdmin) => {
 		if (isAdmin) {
 			fakeUser.roles = { user: true, admin: true };
-		}
-		else {
+		} else {
 			fakeUser.roles = { user: true };
 		}
 	};
@@ -74,7 +71,6 @@ describe('Feedback Controller', () => {
 			{ name: 'admin', isAdmin: true }
 		].forEach((testConfig) => {
 			it(`should submit feedback successfully as ${testConfig.name}`, (done) => {
-
 				setAdmin(testConfig.isAdmin);
 
 				const spec = {
@@ -98,7 +94,6 @@ describe('Feedback Controller', () => {
 		});
 
 		it('should get an error submitting invalid feedback', (done) => {
-
 			const spec = {
 				// missing body
 				type: 'Bug',
@@ -121,7 +116,6 @@ describe('Feedback Controller', () => {
 	});
 
 	describe('POST /admin/feedback', () => {
-
 		let savedFeedback;
 
 		before(() => {
@@ -133,8 +127,8 @@ describe('Feedback Controller', () => {
 						url: 'http://localhost:3000/home',
 						type: 'Question'
 					})
-					.save()
-					.then((result) => savedFeedback = result);
+						.save()
+						.then((result) => (savedFeedback = result));
 				});
 		});
 
@@ -143,7 +137,6 @@ describe('Feedback Controller', () => {
 			{ name: 'should get feedback as admin', isAdmin: true }
 		].forEach((testConfig) => {
 			it(testConfig.name, (done) => {
-
 				setAdmin(testConfig.isAdmin);
 
 				request(app)
@@ -152,20 +145,18 @@ describe('Feedback Controller', () => {
 					.expect('Content-Type', /json/)
 					.expect(testConfig.isAdmin ? 200 : 403)
 					.expect((res) => {
-
 						if (testConfig.isAdmin) {
 							const expected = savedFeedback.toJSON();
 							expected._id = expected._id.toString();
 
 							should(res.body).eql({
-								elements: [ expected ],
+								elements: [expected],
 								pageNumber: 0,
 								pageSize: 20,
 								totalPages: 1,
 								totalSize: 1
 							});
-						}
-						else {
+						} else {
 							should(res.body).eql({
 								message: 'This is a fake error message'
 							});
@@ -176,4 +167,114 @@ describe('Feedback Controller', () => {
 		});
 	});
 
+	describe('PATCH /admin/feedback/:feedbackId/status', () => {
+		let savedFeedback;
+
+		before(() => {
+			return Feedback.deleteMany({})
+				.exec()
+				.then(() => {
+					return new Feedback({
+						body: 'testing',
+						url: 'http://localhost:3000/home',
+						type: 'Question'
+					})
+						.save()
+						.then((result) => (savedFeedback = result));
+				});
+		});
+
+		[
+			{
+				name: 'should not update feedback status as non-admin',
+				isAdmin: false
+			},
+			{ name: 'should update feedback status as admin', isAdmin: true }
+		].forEach((testConfig) => {
+			it(testConfig.name, (done) => {
+				const updatedStatus = 'Closed';
+				setAdmin(testConfig.isAdmin);
+				request(app)
+					.patch(`/admin/feedback/${savedFeedback._id}/status`)
+					.send({ status: updatedStatus })
+					.expect('Content-Type', /json/)
+					.expect(testConfig.isAdmin ? 200 : 403)
+					.expect((res) => {
+						if (testConfig.isAdmin) {
+							const expected = savedFeedback.toJSON();
+							expected._id = expected._id.toString();
+							expected.status = updatedStatus;
+							// Verify that the 'updated' field was updated
+							should(res.body.updated).greaterThan(
+								expected.updated
+							);
+							// Set the expected 'updated' value to be the received value so the match can be performed
+							expected.updated = res.body.updated;
+							should(res.body).match(expected);
+						} else {
+							should(res.body).eql({
+								message: 'This is a fake error message'
+							});
+						}
+					})
+					.end(done);
+			});
+		});
+	});
+
+	describe('PATCH /admin/feedback/:feedbackId/assignee', () => {
+		let savedFeedback;
+
+		before(() => {
+			return Feedback.deleteMany({})
+				.exec()
+				.then(() => {
+					return new Feedback({
+						body: 'testing',
+						url: 'http://localhost:3000/home',
+						type: 'Question'
+					})
+						.save()
+						.then((result) => (savedFeedback = result));
+				});
+		});
+
+		[
+			{
+				name: 'should not update feedback assignee as non-admin',
+				isAdmin: false
+			},
+			{ name: 'should update feedback assignee as admin', isAdmin: true }
+		].forEach((testConfig) => {
+			it(testConfig.name, (done) => {
+				const updatedAssignee = fakeUser.username;
+				setAdmin(testConfig.isAdmin);
+				request(app)
+					.patch(`/admin/feedback/${savedFeedback._id}/assignee`)
+					.send({ assignee: updatedAssignee })
+					.expect('Content-Type', /json/)
+					.expect(testConfig.isAdmin ? 200 : 403)
+					.expect((res) => {
+						if (testConfig.isAdmin) {
+							const expected = savedFeedback.toJSON();
+							expected._id = expected._id.toString();
+							expected.assignee = updatedAssignee;
+
+							// Verify that the 'updated' field was updated
+							should(res.body.updated).greaterThan(
+								expected.updated
+							);
+							// Set the expected 'updated' value to be the received value so the match can be performed
+							expected.updated = res.body.updated;
+							should(res.body).match(expected);
+						} else {
+							should(res.body).eql({
+								message: 'This is a fake error message'
+							});
+						}
+					})
+					.end(done);
+			});
+		});
+	});
 });

--- a/src/app/core/feedback/feedback.controller.spec.js
+++ b/src/app/core/feedback/feedback.controller.spec.js
@@ -118,18 +118,13 @@ describe('Feedback Controller', () => {
 	describe('POST /admin/feedback', () => {
 		let savedFeedback;
 
-		before(() => {
-			return Feedback.deleteMany({})
-				.exec()
-				.then(() => {
-					return new Feedback({
-						body: 'testing',
-						url: 'http://localhost:3000/home',
-						type: 'Question'
-					})
-						.save()
-						.then((result) => (savedFeedback = result));
-				});
+		before(async () => {
+			await Feedback.deleteMany({}).exec();
+			savedFeedback = await new Feedback({
+				body: 'testing',
+				url: 'http://localhost:3000/home',
+				type: 'Question'
+			}).save();
 		});
 
 		[
@@ -170,18 +165,13 @@ describe('Feedback Controller', () => {
 	describe('PATCH /admin/feedback/:feedbackId/status', () => {
 		let savedFeedback;
 
-		before(() => {
-			return Feedback.deleteMany({})
-				.exec()
-				.then(() => {
-					return new Feedback({
-						body: 'testing',
-						url: 'http://localhost:3000/home',
-						type: 'Question'
-					})
-						.save()
-						.then((result) => (savedFeedback = result));
-				});
+		before(async () => {
+			await Feedback.deleteMany({}).exec();
+			savedFeedback = await new Feedback({
+				body: 'testing',
+				url: 'http://localhost:3000/home',
+				type: 'Question'
+			}).save();
 		});
 
 		[
@@ -225,18 +215,13 @@ describe('Feedback Controller', () => {
 	describe('PATCH /admin/feedback/:feedbackId/assignee', () => {
 		let savedFeedback;
 
-		before(() => {
-			return Feedback.deleteMany({})
-				.exec()
-				.then(() => {
-					return new Feedback({
-						body: 'testing',
-						url: 'http://localhost:3000/home',
-						type: 'Question'
-					})
-						.save()
-						.then((result) => (savedFeedback = result));
-				});
+		before(async () => {
+			await Feedback.deleteMany({}).exec();
+			savedFeedback = await new Feedback({
+				body: 'testing',
+				url: 'http://localhost:3000/home',
+				type: 'Question'
+			}).save();
 		});
 
 		[

--- a/src/app/core/feedback/feedback.controller.spec.js
+++ b/src/app/core/feedback/feedback.controller.spec.js
@@ -210,6 +210,40 @@ describe('Feedback Controller', () => {
 					.end(done);
 			});
 		});
+
+		it('should throw a 400 error if supplied with an invalid feedback ID', (done) => {
+			setAdmin(true);
+			request(app)
+				.patch('/admin/feedback/invalid/status')
+				.send({ status: 'Closed' })
+				.expect('Content-Type', /json/)
+				.expect(400)
+				.expect((res) => {
+					should(res.body).eql({
+						message: 'Invalid feedback ID',
+						status: 400,
+						type: 'validation'
+					});
+				})
+				.end(done);
+		});
+
+		it('should throw a 404 error if supplied with a feedback ID that does not exist', (done) => {
+			setAdmin(true);
+			request(app)
+				.patch('/admin/feedback/123412341234/status')
+				.send({ status: 'Closed' })
+				.expect('Content-Type', /json/)
+				.expect(404)
+				.expect((res) => {
+					should(res.body).eql({
+						message: 'Could not find feedback',
+						status: 404,
+						type: 'not-found'
+					});
+				})
+				.end(done);
+		});
 	});
 
 	describe('PATCH /admin/feedback/:feedbackId/assignee', () => {
@@ -260,6 +294,40 @@ describe('Feedback Controller', () => {
 					})
 					.end(done);
 			});
+		});
+
+		it('should throw a 400 error if supplied with an invalid feedback ID', (done) => {
+			setAdmin(true);
+			request(app)
+				.patch('/admin/feedback/invalid/assignee')
+				.send({ status: 'Closed' })
+				.expect('Content-Type', /json/)
+				.expect(400)
+				.expect((res) => {
+					should(res.body).eql({
+						message: 'Invalid feedback ID',
+						status: 400,
+						type: 'validation'
+					});
+				})
+				.end(done);
+		});
+
+		it('should throw a 404 error if supplied with a feedback ID that does not exist', (done) => {
+			setAdmin(true);
+			request(app)
+				.patch('/admin/feedback/123412341234/assignee')
+				.send({ status: 'Closed' })
+				.expect('Content-Type', /json/)
+				.expect(404)
+				.expect((res) => {
+					should(res.body).eql({
+						message: 'Could not find feedback',
+						status: 404,
+						type: 'not-found'
+					});
+				})
+				.end(done);
 		});
 	});
 });

--- a/src/app/core/feedback/feedback.model.js
+++ b/src/app/core/feedback/feedback.model.js
@@ -1,16 +1,15 @@
 'use strict';
 
-const
-	mongoose = require('mongoose'),
-	getterPlugin = require('../../common/mongoose/getter.plugin'),
+const mongoose = require('mongoose'),
 	pagingSearchPlugin = require('../../common/mongoose/paging-search.plugin'),
 	deps = require('../../../dependencies'),
-	util = deps.utilService;
+	util = deps.utilService,
+	GetterSchema = deps.schemaService.GetterSchema;
 
 /**
  * Schema Declaration
  */
-const FeedbackSchema = new mongoose.Schema({
+const FeedbackSchema = new GetterSchema({
 	created: {
 		type: Date,
 		default: Date.now,
@@ -25,9 +24,17 @@ const FeedbackSchema = new mongoose.Schema({
 	url: { type: String },
 	os: { type: String },
 	browser: { type: String },
-	classification: { type: String }
+	classification: { type: String },
+	status: { type: String, default: 'New', required: true },
+	assignee: { type: String },
+	updated: {
+		type: Date,
+		default: Date.now,
+		get: util.dateParse,
+		required: true
+	}
 });
-FeedbackSchema.plugin(getterPlugin);
+
 FeedbackSchema.plugin(pagingSearchPlugin);
 
 /**
@@ -35,21 +42,20 @@ FeedbackSchema.plugin(pagingSearchPlugin);
  */
 
 // Created datetime index, expires after 180 days
-FeedbackSchema.index({ 'created': -1 }, { expireAfterSeconds: 15552000 });
+FeedbackSchema.index({ created: -1 }, { expireAfterSeconds: 15552000 });
 
-FeedbackSchema.index({ 'type': 1 });
-FeedbackSchema.index({ 'creator': 1 });
-FeedbackSchema.index({ 'url': 1 });
-FeedbackSchema.index({ 'os': 1 });
-FeedbackSchema.index({ 'browser': 1 });
+FeedbackSchema.index({ type: 1 });
+FeedbackSchema.index({ creator: 1 });
+FeedbackSchema.index({ url: 1 });
+FeedbackSchema.index({ os: 1 });
+FeedbackSchema.index({ browser: 1 });
 
 // Text-search index
-FeedbackSchema.index({ 'body': 'text' });
+FeedbackSchema.index({ body: 'text' });
 
 /*****************
  * Lifecycle hooks
  *****************/
-
 
 /*****************
  * Static Methods

--- a/src/app/core/feedback/feedback.model.js
+++ b/src/app/core/feedback/feedback.model.js
@@ -26,7 +26,7 @@ const FeedbackSchema = new mongoose.Schema({
 	os: { type: String },
 	browser: { type: String },
 	classification: { type: String },
-	status: { type: String, default: 'New', required: true },
+	status: { type: String, default: 'New', enum: ['New', 'Open', 'Closed'], required: true },
 	assignee: { type: String },
 	updated: {
 		type: Date,

--- a/src/app/core/feedback/feedback.model.js
+++ b/src/app/core/feedback/feedback.model.js
@@ -1,15 +1,16 @@
 'use strict';
 
-const mongoose = require('mongoose'),
+const
+	mongoose = require('mongoose'),
+	getterPlugin = require('../../common/mongoose/getter.plugin'),
 	pagingSearchPlugin = require('../../common/mongoose/paging-search.plugin'),
 	deps = require('../../../dependencies'),
-	util = deps.utilService,
-	GetterSchema = deps.schemaService.GetterSchema;
+	util = deps.utilService;
 
 /**
  * Schema Declaration
  */
-const FeedbackSchema = new GetterSchema({
+const FeedbackSchema = new mongoose.Schema({
 	created: {
 		type: Date,
 		default: Date.now,
@@ -35,6 +36,7 @@ const FeedbackSchema = new GetterSchema({
 	}
 });
 
+FeedbackSchema.plugin(getterPlugin);
 FeedbackSchema.plugin(pagingSearchPlugin);
 
 /**
@@ -49,6 +51,8 @@ FeedbackSchema.index({ creator: 1 });
 FeedbackSchema.index({ url: 1 });
 FeedbackSchema.index({ os: 1 });
 FeedbackSchema.index({ browser: 1 });
+FeedbackSchema.index({ status: 1 });
+FeedbackSchema.index({ assignee: 1 });
 
 // Text-search index
 FeedbackSchema.index({ body: 'text' });

--- a/src/app/core/feedback/feedback.routes.js
+++ b/src/app/core/feedback/feedback.routes.js
@@ -72,10 +72,164 @@ router
 
 router.route('/admin/feedback').post(user.hasAdminAccess, feedback.search);
 
+/**
+ * @swagger
+ * /admin/feedback/{feedbackId}/status:
+ *   patch:
+ *     tags: [Feedback]
+ *     description: >
+ *       Updates the status of the feedback with the supplied ID
+ *     requestBody:
+ *       description: >
+ *             The value to update the Feedback status to
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               status:
+ *                 type: string
+ *     responses:
+ *       '200':
+ *         description: Feedback status was updated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Feedback'
+ *       '400':
+ *         description: User attempted to update feedback with invalid ID
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: number
+ *                 type:
+ *                   type: string
+ *                 message:
+ *                   type: string
+ *               example:
+ *                 status: 400
+ *                 type: 'validation'
+ *                 message: 'Invalid feedback ID'
+ *       '401':
+ *         description: Anonymous user attempted to update feedback status
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: number
+ *                 type:
+ *                   type: string
+ *                 message:
+ *                   type: string
+ *               example:
+ *                 status: 401
+ *                 type: 'no-login'
+ *                 message: 'User is not logged in'
+ *       '404':
+ *         description: Unable to find feedback with the supplied ID
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: number
+ *                 type:
+ *                   type: string
+ *                 message:
+ *                   type: string
+ *               example:
+ *                 status: 404
+ *                 type: 'not-found'
+ *                 message: 'Could not find feedback'
+ */
 router
 	.route('/admin/feedback/:feedbackId/status')
 	.patch(user.hasAdminAccess, feedback.updateFeedbackStatus);
 
+/**
+ * @swagger
+ * /admin/feedback/{feedbackId}/assignee:
+ *   patch:
+ *     tags: [Feedback]
+ *     description: >
+ *       Updates the assignee of the feedback with the supplied ID
+ *     requestBody:
+ *       description: >
+ *             The username to update the Feedback assignee to
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               assignee:
+ *                 type: string
+ *     responses:
+ *       '200':
+ *         description: Feedback assignee was updated successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/Feedback'
+ *       '400':
+ *         description: User attempted to update feedback with invalid ID
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: number
+ *                 type:
+ *                   type: string
+ *                 message:
+ *                   type: string
+ *               example:
+ *                 status: 400
+ *                 type: 'validation'
+ *                 message: 'Invalid feedback ID'
+ *       '401':
+ *         description: Anonymous user attempted to update feedback assignee
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: number
+ *                 type:
+ *                   type: string
+ *                 message:
+ *                   type: string
+ *               example:
+ *                 status: 401
+ *                 type: 'no-login'
+ *                 message: 'User is not logged in'
+ *       '404':
+ *         description: Unable to find feedback with the supplied ID
+ *         content:
+ *           application/json:
+ *             schema:
+ *               type: object
+ *               properties:
+ *                 status:
+ *                   type: number
+ *                 type:
+ *                   type: string
+ *                 message:
+ *                   type: string
+ *               example:
+ *                 status: 404
+ *                 type: 'not-found'
+ *                 message: 'Could not find feedback'
+ */
 router
 	.route('/admin/feedback/:feedbackId/assignee')
 	.patch(user.hasAdminAccess, feedback.updateFeedbackAssignee);

--- a/src/app/core/feedback/feedback.routes.js
+++ b/src/app/core/feedback/feedback.routes.js
@@ -84,4 +84,6 @@ router
 	.route('/admin/feedback/csv/:exportId')
 	.get(user.hasAdminAccess, feedback.adminGetFeedbackCSV);
 
+router.param('feedbackId', feedback.feedbackById);
+
 module.exports = router;

--- a/src/app/core/feedback/feedback.routes.js
+++ b/src/app/core/feedback/feedback.routes.js
@@ -1,10 +1,8 @@
 'use strict';
 
 const express = require('express'),
-
 	feedback = require('./feedback.controller'),
 	user = require('../user/user.controller');
-
 
 const router = express.Router();
 
@@ -68,13 +66,22 @@ const router = express.Router();
  *                 type: 'no-login'
  *                 message: 'User is not logged in'
  */
-router.route('/feedback')
+router
+	.route('/feedback')
 	.post(user.has(user.requiresLogin), feedback.submitFeedback);
 
-router.route('/admin/feedback')
-	.post(user.hasAdminAccess, feedback.search);
+router.route('/admin/feedback').post(user.hasAdminAccess, feedback.search);
 
-router.route('/admin/feedback/csv/:exportId')
+router
+	.route('/admin/feedback/:feedbackId/status')
+	.patch(user.hasAdminAccess, feedback.updateFeedbackStatus);
+
+router
+	.route('/admin/feedback/:feedbackId/assignee')
+	.patch(user.hasAdminAccess, feedback.updateFeedbackAssignee);
+
+router
+	.route('/admin/feedback/csv/:exportId')
 	.get(user.hasAdminAccess, feedback.adminGetFeedbackCSV);
 
 module.exports = router;

--- a/src/app/core/feedback/feedback.routes.js
+++ b/src/app/core/feedback/feedback.routes.js
@@ -9,6 +9,14 @@ const router = express.Router();
 /**
  * @swagger
  * components:
+ *   parameters:
+ *     feedbackIdParam:
+ *       in: path
+ *       name: feedbackId
+ *       required: true
+ *       schema:
+ *         type: string
+ *       description: the unique id of the feedback
  *   schemas:
  *     Feedback:
  *       type: object
@@ -79,6 +87,8 @@ router.route('/admin/feedback').post(user.hasAdminAccess, feedback.search);
  *     tags: [Feedback]
  *     description: >
  *       Updates the status of the feedback with the supplied ID
+ *     parameters:
+ *       - $ref: '#/components/parameters/feedbackIdParam'
  *     requestBody:
  *       description: >
  *             The value to update the Feedback status to
@@ -160,6 +170,8 @@ router
  *     tags: [Feedback]
  *     description: >
  *       Updates the assignee of the feedback with the supplied ID
+ *     parameters:
+ *       - $ref: '#/components/parameters/feedbackIdParam'
  *     requestBody:
  *       description: >
  *             The username to update the Feedback assignee to

--- a/src/app/core/feedback/feedback.service.js
+++ b/src/app/core/feedback/feedback.service.js
@@ -88,7 +88,7 @@ const search = async (reqUser, queryParams, query) => {
 
 const readFeedback = async (feedbackId, populate = []) => {
 	if (!mongoose.Types.ObjectId.isValid(feedbackId)) {
-		throw { status: 400, message: 'Invalid feedback ID' };
+		throw { status: 400, type: 'validation', message: 'Invalid feedback ID' };
 	}
 	const feedback = await Feedback.findOne({
 		_id: feedbackId
@@ -96,7 +96,7 @@ const readFeedback = async (feedbackId, populate = []) => {
 		.populate(populate)
 		.exec();
 	if (null == feedback) {
-		throw { status: 404, message: 'Could not find feedback' };
+		throw { status: 404, type: 'not-found', message: 'Could not find feedback' };
 	}
 	return feedback;
 };

--- a/src/app/core/feedback/feedback.service.js
+++ b/src/app/core/feedback/feedback.service.js
@@ -1,30 +1,40 @@
 'use strict';
 
-const
-	deps = require('../../../dependencies'),
+const deps = require('../../../dependencies'),
 	dbs = deps.dbs,
 	config = deps.config,
 	emailService = deps.emailService,
 	util = deps.utilService,
 	logger = deps.logger,
-	Feedback = dbs.admin.model('Feedback');
+	Feedback = dbs.admin.model('Feedback'),
+	mongoose = require('mongoose');
 
 const sendFeedback = async (user, feedback, req) => {
-	if (null == user || null == feedback.body || null == feedback.type || null == feedback.url) {
+	if (
+		null == user ||
+		null == feedback.body ||
+		null == feedback.type ||
+		null == feedback.url
+	) {
 		return Promise.reject({ status: 400, message: 'Invalid submission.' });
 	}
 
 	try {
-		const mailOptions = await emailService.generateMailOptions(user, req, config.coreEmails.feedbackEmail, {
-			url: feedback.url,
-			feedback: feedback.body,
-			feedbackType: feedback.type
-		});
+		const mailOptions = await emailService.generateMailOptions(
+			user,
+			req,
+			config.coreEmails.feedbackEmail,
+			{
+				url: feedback.url,
+				feedback: feedback.body,
+				feedbackType: feedback.type
+			}
+		);
 		await emailService.sendMail(mailOptions);
 		logger.debug(`Sent approved user (${user.username}) alert email`);
 	} catch (error) {
 		// Log the error but this shouldn't block
-		logger.error({err: error, req: req}, 'Failure sending email.');
+		logger.error({ err: error, req: req }, 'Failure sending email.');
 	}
 };
 
@@ -43,7 +53,10 @@ const create = async (reqUser, newFeedback, userSpec) => {
 		return await feedback.save();
 	} catch (err) {
 		// Log and continue the error
-		logger.error({err: err, feedback: newFeedback}, 'Error trying to persist feedback record to storage.');
+		logger.error(
+			{ err: err, feedback: newFeedback },
+			'Error trying to persist feedback record to storage.'
+		);
 		return Promise.reject(err);
 	}
 };
@@ -56,16 +69,51 @@ const search = async (reqUser, queryParams, query) => {
 	const offset = page * limit;
 
 	// Query for feedback
-	const feedback = await Feedback.textSearch(query, null, limit, offset, sortArr, true, {
-		path: 'creator',
-		select: ['name', 'email']
-	});
+	const feedback = await Feedback.textSearch(
+		query,
+		null,
+		limit,
+		offset,
+		sortArr,
+		true,
+		{
+			path: 'creator',
+			select: ['username', 'organization', 'name', 'email']
+		}
+	);
 
 	return util.getPagingResults(limit, page, feedback.count, feedback.results);
+};
+
+const getFeedbackById = async (feedbackId) => {
+	return await Feedback.findOne({
+		_id: mongoose.Types.ObjectId(feedbackId)
+	}).populate({
+		path: 'creator',
+		select: ['username', 'organization', 'name', 'email']
+	});
+};
+
+const updateFeedbackAssignee = async (feedbackId, assignee) => {
+	const feedback = await getFeedbackById(feedbackId);
+	feedback.assignee = assignee;
+	feedback.updated = Date.now();
+	await feedback.save();
+	return feedback;
+};
+
+const updateFeedbackStatus = async (feedbackId, status) => {
+	const feedback = await getFeedbackById(feedbackId);
+	feedback.status = status;
+	feedback.updated = Date.now();
+	await feedback.save();
+	return feedback;
 };
 
 module.exports = {
 	create,
 	search,
-	sendFeedback
+	sendFeedback,
+	updateFeedbackAssignee,
+	updateFeedbackStatus
 };

--- a/src/app/core/feedback/feedback.service.js
+++ b/src/app/core/feedback/feedback.service.js
@@ -95,9 +95,6 @@ const readFeedback = async (feedbackId, populate = []) => {
 	})
 		.populate(populate)
 		.exec();
-	if (null == feedback) {
-		throw { status: 404, type: 'not-found', message: 'Could not find feedback' };
-	}
 	return feedback;
 };
 

--- a/src/app/core/feedback/feedback.service.js
+++ b/src/app/core/feedback/feedback.service.js
@@ -86,35 +86,38 @@ const search = async (reqUser, queryParams, query) => {
 	return util.getPagingResults(limit, page, feedback.count, feedback.results);
 };
 
-const getFeedbackById = async (feedbackId) => {
-	return Feedback.findOne({
-		_id: mongoose.Types.ObjectId(feedbackId)
-	}).populate({
-		path: 'creator',
-		select: ['username', 'organization', 'name', 'email']
-	});
+const readFeedback = async (feedbackId, populate = []) => {
+	if (!mongoose.Types.ObjectId.isValid(feedbackId)) {
+		throw { status: 400, message: 'Invalid feedback ID' };
+	}
+	const feedback = await Feedback.findOne({
+		_id: feedbackId
+	})
+		.populate(populate)
+		.exec();
+	if (null == feedback) {
+		throw { status: 404, message: 'Could not find feedback' };
+	}
+	return feedback;
 };
 
-const updateFeedbackAssignee = async (feedbackId, assignee) => {
-	const feedback = await getFeedbackById(feedbackId);
+const updateFeedbackAssignee = async (feedback, assignee) => {
 	feedback.assignee = assignee;
 	feedback.updated = Date.now();
-	await feedback.save();
-	return feedback;
+	return await feedback.save();
 };
 
-const updateFeedbackStatus = async (feedbackId, status) => {
-	const feedback = await getFeedbackById(feedbackId);
+const updateFeedbackStatus = async (feedback, status) => {
 	feedback.status = status;
 	feedback.updated = Date.now();
-	await feedback.save();
-	return feedback;
+	return await feedback.save();
 };
 
 module.exports = {
 	create,
 	search,
 	sendFeedback,
+	readFeedback,
 	updateFeedbackAssignee,
 	updateFeedbackStatus
 };

--- a/src/app/core/feedback/feedback.service.js
+++ b/src/app/core/feedback/feedback.service.js
@@ -1,6 +1,7 @@
 'use strict';
 
-const deps = require('../../../dependencies'),
+const
+	deps = require('../../../dependencies'),
 	dbs = deps.dbs,
 	config = deps.config,
 	emailService = deps.emailService,
@@ -86,7 +87,7 @@ const search = async (reqUser, queryParams, query) => {
 };
 
 const getFeedbackById = async (feedbackId) => {
-	return await Feedback.findOne({
+	return Feedback.findOne({
 		_id: mongoose.Types.ObjectId(feedbackId)
 	}).populate({
 		path: 'creator',

--- a/src/app/core/feedback/feedback.service.spec.js
+++ b/src/app/core/feedback/feedback.service.spec.js
@@ -109,17 +109,9 @@ FOOTER
 			error.type.should.equal('validation');
 		});
 
-		it('should throw a 404 errorResult if a nonexistent feedback ID is supplied', async () => {
-			let error = null;
-			try {
-				await feedbackService.readFeedback('123412341234');
-			} catch(e) {
-				error = e;
-			}
-			should.exist(error);
-			error.status.should.equal(404);
-			error.message.should.equal('Could not find feedback');
-			error.type.should.equal('not-found');
+		it('should return null if a nonexistent feedback ID is supplied', async () => {
+			const feedback = await feedbackService.readFeedback('123412341234');
+			should.not.exist(feedback);
 		});
 	});
 });

--- a/src/app/core/feedback/feedback.service.spec.js
+++ b/src/app/core/feedback/feedback.service.spec.js
@@ -3,8 +3,8 @@
 const
 	should = require('should'),
 	proxyquire = require('proxyquire'),
-
 	deps = require('../../../dependencies'),
+	Feedback = deps.dbs.admin.model('Feedback'),
 	config = deps.config;
 
 /**
@@ -85,4 +85,41 @@ FOOTER
 		});
 	});
 
+	describe('readFeedback', () => {
+		it('should return feedback if a feedback ID is supplied', async () => {
+			const savedFeedback = await new Feedback({
+				body: 'testing',
+				url: 'http://localhost:3000/home',
+				type: 'Question'
+			}).save();
+			const feedback = await feedbackService.readFeedback( savedFeedback._id);
+			should.exist(feedback);
+		});
+
+		it('should throw a 400 errorResult if an invalid feedback ID is supplied', async () => {
+			let error = null;
+			try {
+				await feedbackService.readFeedback( '1234');
+			} catch(e) {
+				error = e;
+			}
+			should.exist(error);
+			error.status.should.equal(400);
+			error.message.should.equal('Invalid feedback ID');
+			error.type.should.equal('validation');
+		});
+
+		it('should throw a 404 errorResult if a nonexistent feedback ID is supplied', async () => {
+			let error = null;
+			try {
+				await feedbackService.readFeedback('123412341234');
+			} catch(e) {
+				error = e;
+			}
+			should.exist(error);
+			error.status.should.equal(404);
+			error.message.should.equal('Could not find feedback');
+			error.type.should.equal('not-found');
+		});
+	});
 });


### PR DESCRIPTION
This PR contains modifications to the `Feedback` routes, controller, service, and model. This is being done with the intention of expanding the `Feedback` functionality to be more like other admin services (like user service) and add some new functionality as well.  There is an accompanying PR for the `ngx-starter` with the UI changes that would use this server functionality (https://github.com/Asymmetrik/ngx-starter/pull/192).

**Change Summary:**
- Added 3 new fields to `Feedback` model, `status`, `assignee`, and `updated`. These are made with the intention of allowing a sort of in-app tracking system to allow admins to organize handling feedback.
- Added 2 new routes and accompanying controller and service methods to update `status` and `feedback` individually.
- Modified CSV export to use a column config posted with the export request instead of defaulting to including all columns. This allows users to select which columns they want exported based on what columns they have showing in the UI (modeled after `User` service).
- Modified the search to take in filter queries to enable UI Quick Filters (modeled after `User` service).

**Verification Steps**
While these updates can be verified using Postman or something, it's easier to do it through the UI. See https://github.com/Asymmetrik/ngx-starter/pull/192 for verification steps that include this functionality.

Let me know what I can improve! Thanks!