### PR TITLE
docs: Add support for openapi yml files

### DIFF
--- a/config/assets.js
+++ b/config/assets.js
@@ -9,5 +9,6 @@ module.exports = {
 	models: [ 'src/**/*.model!(.spec).js' ],
 	routes: [ 'src/**/*.routes!(.spec).js' ],
 	sockets: [ 'src/**/*.socket!(.spec).js' ],
-	config: [ 'src/**/*.config!(.spec).js' ]
+	config: [ 'src/**/*.config!(.spec).js' ],
+	docs: [ 'src/**/*/*.components.yml' ]
 };

--- a/src/app/core/core.components.yml
+++ b/src/app/core/core.components.yml
@@ -1,0 +1,81 @@
+components:
+  schemas:
+    Error:
+      type: object
+      properties:
+        status:
+          type: number
+        type:
+          type: string
+        message:
+          type: string
+    ResultsPage:
+      type: object
+      properties:
+        pageNumber:
+          type: integer
+        pageSize:
+          type: integer
+        totalPages:
+          type: integer
+        totalSize:
+          type: integer
+      example:
+        pageNumber: 0
+        pageSize: 20
+        totalPages: 10
+        totalSize: 200
+        items: []
+  parameters:
+    pageParam:
+      in: query
+      name: page
+      schema:
+        type: integer
+      description: Page number
+    sizeParam:
+      in: query
+      name: size
+      schema:
+        type: integer
+      description: Number of results to return (result per page)
+    sortParam:
+      in: query
+      name: sort
+      schema:
+        type: string
+      description: Field name to sort by
+    dirParam:
+      in: query
+      name: dir
+      schema:
+        type: string
+      description: Sort direction (ASC or DESC)
+  requestBodies:
+    SearchCriteria:
+      description: >
+        Object contains property q: a mongo query, and/or s: a string to search contents of text indexed fields.
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              s:
+                type: string
+              q:
+                type: object
+            example:
+              s: 'search string'
+              q: { }
+  responses:
+    NotAuthenticated:
+      description: User not authenticated
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            status: 400
+            type: 'missing-credentials'
+            message: 'Missing credentials'
+

--- a/src/app/core/feedback/feedback.components.yml
+++ b/src/app/core/feedback/feedback.components.yml
@@ -1,0 +1,108 @@
+components:
+  schemas:
+    FeedbackCreate:
+      type: object
+      properties:
+        body:
+          type: string
+        url:
+          type: string
+        type:
+          type: string
+        classification:
+          type: string
+      example:
+        body: 'This is a great tool! Thanks for building it.'
+        url: 'http://localhost:3000/#/path/to/page'
+        type: 'Bug'
+        classification: 'CLASS 1'
+    Feedback:
+      allOf:
+        - $ref: '#/components/schemas/FeedbackCreate'
+        - type: object
+          properties:
+            _id:
+              type: string
+            status:
+              type: string
+              enum: [New, Open, Closed]
+            browser:
+              type: string
+            os:
+              type: string
+            created:
+              type: number
+            updated:
+              type: number
+            creator:
+              type: object
+              properties:
+                _id:
+                  type: string
+                username:
+                  type: string
+                name:
+                  type: string
+                email:
+                  type: string
+                organization:
+                  type: string
+      example:
+        _id: '12312312312312313'
+        status: 'New'
+        browser: 'Chrome 89.0.4389.90'
+        os: 'Windows'
+        created: 1617738797588
+        updated: 1617738797588
+        body: 'This is a great tool! Thanks for building it.'
+        url: 'http://localhost:3000/#/path/to/page'
+        type: 'Bug'
+        classification: 'CLASS 1'
+    FeedbackPage:
+      allOf:
+        - $ref: '#/components/schemas/ResultsPage'
+        - type: object
+          properties:
+            elements:
+              type: array
+              items:
+                $ref: '#/components/schemas/Feedback'
+  parameters:
+    feedbackIdParam:
+      in: path
+      name: feedbackId
+      required: true
+      schema:
+        type: string
+      description: the unique id of the feedback
+  responses:
+    FeedbackNotFound:
+      description: Unable to find feedback with the supplied ID
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            status: 404
+            type: 'not-found'
+            message: 'Could not find feedback'
+    FeedbackUpdateInvalidId:
+      description: User attempted to update feedback with invalid ID
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            status: 400
+            type: 'validation'
+            message: 'Invalid feedback ID'
+    FeedbackUpdateAnonymousUser:
+      description: Anonymous user attempted to update feedback
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+          example:
+            status: 401
+            type: 'no-login'
+            message: 'User is not logged in'

--- a/src/app/core/feedback/feedback.routes.js
+++ b/src/app/core/feedback/feedback.routes.js
@@ -8,33 +8,6 @@ const router = express.Router();
 
 /**
  * @swagger
- * components:
- *   parameters:
- *     feedbackIdParam:
- *       in: path
- *       name: feedbackId
- *       required: true
- *       schema:
- *         type: string
- *       description: the unique id of the feedback
- *   schemas:
- *     Feedback:
- *       type: object
- *       properties:
- *         body:
- *           type: string
- *         url:
- *           type: string
- *         type:
- *           type: string
- *       example:
- *         body: 'This is a great tool! Thanks for building it.'
- *         url: 'http://localhost:3000/#/path/to/page'
- *         type: 'Bug'
- */
-
-/**
- * @swagger
  * /feedback:
  *   post:
  *     tags: [Feedback]
@@ -48,7 +21,7 @@ const router = express.Router();
  *       content:
  *         application/json:
  *           schema:
- *             $ref: '#/components/schemas/Feedback'
+ *             $ref: '#/components/schemas/FeedbackCreate'
  *     responses:
  *       '200':
  *         description: Feedback was submitted successfully
@@ -61,23 +34,40 @@ const router = express.Router();
  *         content:
  *           application/json:
  *             schema:
- *               type: object
- *               properties:
- *                 status:
- *                   type: number
- *                 type:
- *                   type: string
- *                 message:
- *                   type: string
- *               example:
- *                 status: 401
- *                 type: 'no-login'
- *                 message: 'User is not logged in'
+ *               $ref: '#/components/schemas/Error'
+ *             example:
+ *               status: 401
+ *               type: 'no-login'
+ *               message: 'User is not logged in'
  */
 router
 	.route('/feedback')
 	.post(user.has(user.requiresLogin), feedback.submitFeedback);
 
+/**
+ * @swagger
+ * /admin/feedback:
+ *   post:
+ *     tags: [Feedback]
+ *     description: >
+ *       returns feedback matching search criteria
+ *     requestBody:
+ *       $ref: '#/components/requestBodies/SearchCriteria'
+ *     parameters:
+ *       - $ref: '#/components/parameters/pageParam'
+ *       - $ref: '#/components/parameters/sizeParam'
+ *       - $ref: '#/components/parameters/sortParam'
+ *       - $ref: '#/components/parameters/dirParam'
+ *     responses:
+ *       '200':
+ *         description: Feedback returned successfully
+ *         content:
+ *           application/json:
+ *             schema:
+ *               $ref: '#/components/schemas/FeedbackPage'
+ *       '400':
+ *         $ref: '#/components/responses/NotAuthenticated'
+ */
 router.route('/admin/feedback').post(user.hasAdminAccess, feedback.search);
 
 /**
@@ -100,6 +90,7 @@ router.route('/admin/feedback').post(user.hasAdminAccess, feedback.search);
  *             properties:
  *               status:
  *                 type: string
+ *                 enum: [New, Open, Closed]
  *     responses:
  *       '200':
  *         description: Feedback status was updated successfully
@@ -108,56 +99,11 @@ router.route('/admin/feedback').post(user.hasAdminAccess, feedback.search);
  *             schema:
  *               $ref: '#/components/schemas/Feedback'
  *       '400':
- *         description: User attempted to update feedback with invalid ID
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 status:
- *                   type: number
- *                 type:
- *                   type: string
- *                 message:
- *                   type: string
- *               example:
- *                 status: 400
- *                 type: 'validation'
- *                 message: 'Invalid feedback ID'
+ *         $ref: '#/components/responses/FeedbackUpdateInvalidId'
  *       '401':
- *         description: Anonymous user attempted to update feedback status
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 status:
- *                   type: number
- *                 type:
- *                   type: string
- *                 message:
- *                   type: string
- *               example:
- *                 status: 401
- *                 type: 'no-login'
- *                 message: 'User is not logged in'
+ *         $ref: '#/components/responses/FeedbackUpdateAnonymousUser'
  *       '404':
- *         description: Unable to find feedback with the supplied ID
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 status:
- *                   type: number
- *                 type:
- *                   type: string
- *                 message:
- *                   type: string
- *               example:
- *                 status: 404
- *                 type: 'not-found'
- *                 message: 'Could not find feedback'
+ *         $ref: '#/components/responses/FeedbackNotFound'
  */
 router
 	.route('/admin/feedback/:feedbackId/status')
@@ -191,56 +137,11 @@ router
  *             schema:
  *               $ref: '#/components/schemas/Feedback'
  *       '400':
- *         description: User attempted to update feedback with invalid ID
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 status:
- *                   type: number
- *                 type:
- *                   type: string
- *                 message:
- *                   type: string
- *               example:
- *                 status: 400
- *                 type: 'validation'
- *                 message: 'Invalid feedback ID'
+ *         $ref: '#/components/responses/FeedbackUpdateInvalidId'
  *       '401':
- *         description: Anonymous user attempted to update feedback assignee
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 status:
- *                   type: number
- *                 type:
- *                   type: string
- *                 message:
- *                   type: string
- *               example:
- *                 status: 401
- *                 type: 'no-login'
- *                 message: 'User is not logged in'
+ *         $ref: '#/components/responses/FeedbackUpdateAnonymousUser'
  *       '404':
- *         description: Unable to find feedback with the supplied ID
- *         content:
- *           application/json:
- *             schema:
- *               type: object
- *               properties:
- *                 status:
- *                   type: number
- *                 type:
- *                   type: string
- *                 message:
- *                   type: string
- *               example:
- *                 status: 404
- *                 type: 'not-found'
- *                 message: 'Could not find feedback'
+ *         $ref: '#/components/responses/FeedbackNotFound'
  */
 router
 	.route('/admin/feedback/:feedbackId/assignee')

--- a/src/config.js
+++ b/src/config.js
@@ -112,6 +112,9 @@ function initGlobalConfigFiles(config, assets) {
 
 	// Setting Globbed e2e test files
 	config.files.e2e = getGlobbedPaths(assets.e2e);
+
+	// Setting Globbed doc files
+	config.files.docs = getGlobbedPaths(assets.docs);
 }
 
 function initDerivedConfig(config) {

--- a/src/lib/express.js
+++ b/src/lib/express.js
@@ -217,6 +217,7 @@ function initSwaggerAPI(app) {
 			]
 		},
 		apis: [
+			...config.files.docs.map((doc) => path.posix.resolve(doc)),
 			...config.files.routes.map((route) => path.posix.resolve(route)),
 			...config.files.models.map((model) => path.posix.resolve(model))
 		]

--- a/src/lib/express.spec.js
+++ b/src/lib/express.spec.js
@@ -24,21 +24,21 @@ describe('Init Swagger API:', () => {
 						url: 'https://api.example.com/api'
 					}
 				]
-				// basePath: '/api'
 			},
 			apis: [
+				...config.files.docs.map((doc) => path.posix.resolve(doc)),
 				...config.files.routes.map((route) => path.posix.resolve(route)),
 				...config.files.models.map((model) => path.posix.resolve(model))
 			]
 		};
 
 		if (config.auth.strategy === 'local') {
-			swaggerOptions.swaggerDefinition.components = {
-				securitySchemes: {
-					basicAuth: {
-						type: 'http',
-						scheme: 'basic'
-					}
+			swaggerOptions.swaggerDefinition.components =
+				swaggerOptions.swaggerDefinition.components || {};
+			swaggerOptions.swaggerDefinition.components.securitySchemes = {
+				basicAuth: {
+					type: 'http',
+					scheme: 'basic'
 				}
 			};
 		}


### PR DESCRIPTION
Adds support for defining openapi docs in yml files in addition to jsdoc comments.  Main use will be to define reusable components in yml that can be referenced in the endpoint definintions in route files.
Added core.components.yml with some common components.
Added feedback.components.yml to extract feedback specific components.
Updated documentation for feedback routes to illustrate use.