### PR TITLE
Typecheck Watch Task

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,21 @@
+{
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Compile and watch via TSC",
+            "type": "npm",
+            "script": "tsc:watch",
+            "problemMatcher": "$tsc-watch",
+            "isBackground": true,
+            "presentation": {
+                "reveal": "always",
+                "revealProblems": "onProblem"
+            },
+            "detail": "tsc --watch --noEmit",
+            "group": {
+                "kind": "build",
+                "isDefault": true
+            }
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -24,9 +24,8 @@
     "lint:fix": "npm run lint:eslint:fix",
     "lint:eslint": "eslint \"./**/*.js\"",
     "lint:eslint:fix": "eslint \"./**/*.js\" --fix",
-    "prettier": "prettier --check \"**/*.js\"",
-    "prettier:fix": "prettier --write \"**/*.js\"",
-    "tsc:check": "./node_modules/typescript/bin/tsc --project tsconfig.json --noEmit"
+    "tsc:check": "./node_modules/typescript/bin/tsc --project tsconfig.json --noEmit",
+    "tsc:watch": "tsc --watch --noEmit"
   },
   "nyc": {
     "include": "src",


### PR DESCRIPTION
This adds a new npm run script that allows the tsc to continuously analyze type checking.
This also adds a new VSCode task (which can be run with Terminal > Run Build Task) which will start up the tsc watcher and report any problems found to the VSCode Problems Pane. 

Also this removes the prettier-specific formatting scripts (as formatting fixes should be done through npm lint:fix, which eslint will handoff to prettier under the hood).