### PR TITLE
refactor: Replace paging-search mongoose plugin with separate paginat…

### DIFF
--- a/src/app/common/mongoose/contains-search.plugin.js
+++ b/src/app/common/mongoose/contains-search.plugin.js
@@ -1,0 +1,35 @@
+const deps = require('../../../dependencies'),
+	{ escapeRegex } = deps.utilService;
+
+/**
+ * @param schema
+ * @param {Object} pluginOptions
+ * @param {string[]} [pluginOptions.fields]
+ */
+const containsSearchPlugin = (schema, pluginOptions = {}) => {
+	/**
+	 * @param {string} search
+	 * @param {string[]} [fields]
+	 * @returns {*}
+	 */
+	schema.query.containsSearch = function (
+		search,
+		fields = pluginOptions.fields
+	) {
+		if (null == search || '' === search) {
+			return this;
+		}
+
+		if (null == fields || fields.length === 0) {
+			return this;
+		}
+
+		return this.find({
+			$or: fields.map((element) => ({
+				[element]: { $regex: new RegExp(escapeRegex(search), 'gim') }
+			}))
+		});
+	};
+};
+
+module.exports = containsSearchPlugin;

--- a/src/app/common/mongoose/contains-search.plugin.js
+++ b/src/app/common/mongoose/contains-search.plugin.js
@@ -24,6 +24,11 @@ const containsSearchPlugin = (schema, pluginOptions = {}) => {
 			return this;
 		}
 
+		if (fields.length === 1) {
+			return this.find({
+				[fields[0]]: { $regex: new RegExp(escapeRegex(search), 'gim') }
+			});
+		}
 		return this.find({
 			$or: fields.map((element) => ({
 				[element]: { $regex: new RegExp(escapeRegex(search), 'gim') }

--- a/src/app/common/mongoose/contains-search.plugin.spec.js
+++ b/src/app/common/mongoose/contains-search.plugin.spec.js
@@ -4,6 +4,10 @@ const should = require('should'),
 
 const ContainsExampleSchema = new mongoose.Schema({ field: String });
 ContainsExampleSchema.plugin(containsSearchPlugin);
+
+/**
+ * @type {mongoose.Model<mongoose.Document<any, import('./types').ContainsSearchPlugin>>}
+ */
 const ContainsExample = mongoose.model(
 	'ContainsExample',
 	ContainsExampleSchema
@@ -13,6 +17,10 @@ const ContainsExample2Schema = new mongoose.Schema({ field: String });
 ContainsExample2Schema.plugin(containsSearchPlugin, {
 	fields: ['field1', 'field2']
 });
+
+/**
+ * @type {mongoose.Model<mongoose.Document<any, ContainsSearchPlugin>>}
+ */
 const ContainsExample2 = mongoose.model(
 	'ContainsExample2',
 	ContainsExample2Schema

--- a/src/app/common/mongoose/contains-search.plugin.spec.js
+++ b/src/app/common/mongoose/contains-search.plugin.spec.js
@@ -1,0 +1,86 @@
+const should = require('should'),
+	mongoose = require('mongoose'),
+	containsSearchPlugin = require('./contains-search.plugin');
+
+const ContainsExampleSchema = new mongoose.Schema({ field: String });
+ContainsExampleSchema.plugin(containsSearchPlugin);
+const ContainsExample = mongoose.model(
+	'ContainsExample',
+	ContainsExampleSchema
+);
+
+const ContainsExample2Schema = new mongoose.Schema({ field: String });
+ContainsExample2Schema.plugin(containsSearchPlugin, {
+	fields: ['field1', 'field2']
+});
+const ContainsExample2 = mongoose.model(
+	'ContainsExample2',
+	ContainsExample2Schema
+);
+
+/**
+ * Unit tests
+ */
+describe('Contains Search Plugin:', () => {
+	describe('containsSearch:', () => {
+		it('should add containsSearch function to query', () => {
+			const query = ContainsExample.find();
+			should.exist(query.containsSearch);
+
+			query.containsSearch.should.be.Function();
+		});
+
+		it('should not add to filter if search term is null/undefined/empty string', () => {
+			[null, undefined, ''].forEach((search) => {
+				const query = ContainsExample.find().containsSearch(search);
+
+				const filter = query.getFilter();
+				should.exist(filter);
+				should.not.exist(filter.$or);
+			});
+		});
+
+		it('should not add to filter if field list is empty', () => {
+			[null, []].forEach((fields) => {
+				const query = ContainsExample.find().containsSearch('test', fields);
+
+				const filter = query.getFilter();
+				should.exist(filter);
+				should.not.exist(filter.$or);
+			});
+		});
+
+		it('should use provided fields list', () => {
+			const query = ContainsExample.find().containsSearch('test', [
+				'field1',
+				'field2',
+				'field3'
+			]);
+
+			const filter = query.getFilter();
+			should.exist(filter);
+			should.exist(filter.$or);
+			filter.$or.should.be.an.Array();
+			filter.$or.length.should.equal(3);
+		});
+
+		it('should not create $or if only one field in list', () => {
+			const query = ContainsExample.find().containsSearch('test', ['field1']);
+
+			const filter = query.getFilter();
+			should.exist(filter);
+			should.not.exist(filter.$or);
+			should.exist(filter.field1);
+		});
+
+		it('should use default fields list in pluginOptions', () => {
+			const query = ContainsExample2.find().containsSearch('test');
+
+			const filter = query.getFilter();
+			should.exist(filter);
+			should.exist(filter.$or);
+			filter.$or.should.be.Array();
+			filter.$or.length.should.equal(2);
+		});
+	});
+});

--- a/src/app/common/mongoose/contains-search.plugin.spec.js
+++ b/src/app/common/mongoose/contains-search.plugin.spec.js
@@ -19,7 +19,7 @@ ContainsExample2Schema.plugin(containsSearchPlugin, {
 });
 
 /**
- * @type {mongoose.Model<mongoose.Document<any, ContainsSearchPlugin>>}
+ * @type {mongoose.Model<mongoose.Document<any, import('./types').ContainsSearchPlugin>>}
  */
 const ContainsExample2 = mongoose.model(
 	'ContainsExample2',

--- a/src/app/common/mongoose/paginate.plugin.js
+++ b/src/app/common/mongoose/paginate.plugin.js
@@ -1,0 +1,69 @@
+const deps = require('../../../dependencies'),
+	config = deps.config;
+
+const MONGO_TIMEOUT_ERROR_CODE = 50;
+
+/**
+ * @typedef {Object} PagingResult
+ * @property {number} pageSize
+ * @property {number} pageNumber
+ * @property {number} totalSize
+ * @property {number} totalPages
+ * @property {*[]} elements
+ */
+
+/**
+ * @param schema
+ */
+const paginatePlugin = (schema) => {
+	/**
+	 * @param {number} pageSize
+	 * @param {number} pageNumber
+	 * @param {boolean} runCount
+	 * @param {number} countTimeout
+	 * @returns {Promise<PagingResult>}
+	 */
+	schema.query.paginate = async function (
+		pageSize,
+		pageNumber,
+		runCount = true,
+		countTimeout = config.maxCountTimeMS
+	) {
+		const countPromise = runCount
+			? this.model
+					.find(this.getFilter())
+					.maxTimeMS(countTimeout)
+					.countDocuments()
+					.exec()
+					.catch((err) => {
+						// Hit timeout
+						if (err.code === MONGO_TIMEOUT_ERROR_CODE) {
+							return Promise.resolve(Number.MAX_SAFE_INTEGER);
+						}
+						return err;
+					})
+			: Promise.resolve(Number.MAX_SAFE_INTEGER);
+
+		const resultsPromise = this.skip(pageNumber * pageSize)
+			.limit(pageSize)
+			.maxTimeMS(config.maxTimeMS)
+			.exec();
+
+		const [totalSize, elements] = await Promise.all([
+			countPromise,
+			resultsPromise
+		]);
+		if (totalSize === 0) {
+			pageNumber = 0;
+		}
+		return {
+			pageSize,
+			pageNumber,
+			totalSize,
+			totalPages: Math.ceil(totalSize / pageSize),
+			elements
+		};
+	};
+};
+
+module.exports = paginatePlugin;

--- a/src/app/common/mongoose/paginate.plugin.spec.js
+++ b/src/app/common/mongoose/paginate.plugin.spec.js
@@ -4,6 +4,10 @@ const should = require('should'),
 
 const PaginateExampleSchema = new mongoose.Schema({ field: String });
 PaginateExampleSchema.plugin(paginatePlugin);
+
+/**
+ * @type {mongoose.Model<mongoose.Document<any, import('./types').PaginatePlugin>>}
+ */
 const PaginateExample = mongoose.model(
 	'PaginateExample',
 	PaginateExampleSchema

--- a/src/app/common/mongoose/paginate.plugin.spec.js
+++ b/src/app/common/mongoose/paginate.plugin.spec.js
@@ -1,0 +1,89 @@
+const should = require('should'),
+	mongoose = require('mongoose'),
+	paginatePlugin = require('./paginate.plugin');
+
+const PaginateExampleSchema = new mongoose.Schema({ field: String });
+PaginateExampleSchema.plugin(paginatePlugin);
+const PaginateExample = mongoose.model(
+	'PaginateExample',
+	PaginateExampleSchema
+);
+
+/**
+ * Unit tests
+ */
+describe('Paging Search Plugin:', () => {
+	before(() => {
+		const items = [];
+		for (let i = 1; i <= 100; i++) {
+			items.push(
+				new PaginateExample({
+					field: i
+				})
+			);
+		}
+		return PaginateExample.create(items);
+	});
+
+	after(() => {
+		return PaginateExample.deleteMany({}).exec();
+	});
+
+	it('should add paginate function to query', () => {
+		const query = PaginateExample.find();
+		should.exist(query.paginate);
+
+		query.paginate.should.be.Function();
+	});
+
+	it('should return promise', () => {
+		const promise = PaginateExample.find().paginate(10, 1);
+
+		promise.then.should.be.an.instanceof(Function);
+	});
+
+	it('should return specified page of data', async () => {
+		const result = await PaginateExample.find().paginate(10, 5);
+		should.exist(result);
+		result.should.be.containEql({
+			pageSize: 10,
+			pageNumber: 5,
+			totalSize: 100,
+			totalPages: 10
+		});
+		should.exist(result.elements);
+		result.elements.should.be.an.Array();
+		result.elements.length.should.equal(10);
+	});
+
+	it('should return empty/first page if no data found', async () => {
+		const result = await PaginateExample.find({ field: 'invalid' }).paginate(
+			10,
+			5
+		);
+		should.exist(result);
+		result.should.be.containEql({
+			pageSize: 10,
+			pageNumber: 0,
+			totalSize: 0,
+			totalPages: 0
+		});
+		should.exist(result.elements);
+		result.elements.should.be.an.Array();
+		result.elements.length.should.equal(0);
+	});
+
+	it('should return page with expected metadata when runCount = false', async () => {
+		const result = await PaginateExample.find().paginate(10, 5, false);
+		should.exist(result);
+		result.should.be.containEql({
+			pageSize: 10,
+			pageNumber: 5,
+			totalSize: Number.MAX_SAFE_INTEGER,
+			totalPages: Math.ceil(Number.MAX_SAFE_INTEGER / 10)
+		});
+		should.exist(result.elements);
+		result.elements.should.be.an.Array();
+		result.elements.length.should.equal(10);
+	});
+});

--- a/src/app/common/mongoose/paging-search.plugin.js
+++ b/src/app/common/mongoose/paging-search.plugin.js
@@ -141,6 +141,9 @@ const searchTextQuery = (
 	);
 };
 
+/**
+ * @deprecated migrate to using paginate.plugin, text-search.plugin and contains-search.plugin
+ */
 function pagingSearchPlugin(schema, options) {
 	// Search by text and other criteria
 	schema.statics.textSearch = function (

--- a/src/app/common/mongoose/text-search.plugin.js
+++ b/src/app/common/mongoose/text-search.plugin.js
@@ -1,0 +1,22 @@
+/**
+ * @param schema
+ */
+const textSearchPlugin = (schema) => {
+	/**
+	 * @param {string} search
+	 * @returns {*}
+	 */
+	schema.query.textSearch = function (search) {
+		if (null == search || '' === search) {
+			return this;
+		}
+
+		return this.find({ $text: { $search: search } })
+			.select({
+				score: { $meta: 'textScore' }
+			})
+			.sort({ ...this.getOptions().sort, score: { $meta: 'textScore' } });
+	};
+};
+
+module.exports = textSearchPlugin;

--- a/src/app/common/mongoose/text-search.plugin.spec.js
+++ b/src/app/common/mongoose/text-search.plugin.spec.js
@@ -4,6 +4,10 @@ const should = require('should'),
 
 const TextExampleSchema = new mongoose.Schema({ field: String });
 TextExampleSchema.plugin(textSearchPlugin);
+
+/**
+ * @type {mongoose.Model<mongoose.Document<any, import('./types').TextSearchPlugin>>}
+ */
 const TextExample = mongoose.model('TextExample', TextExampleSchema);
 
 /**

--- a/src/app/common/mongoose/text-search.plugin.spec.js
+++ b/src/app/common/mongoose/text-search.plugin.spec.js
@@ -1,0 +1,53 @@
+const should = require('should'),
+	mongoose = require('mongoose'),
+	textSearchPlugin = require('./text-search.plugin');
+
+const TextExampleSchema = new mongoose.Schema({ field: String });
+TextExampleSchema.plugin(textSearchPlugin);
+const TextExample = mongoose.model('TextExample', TextExampleSchema);
+
+/**
+ * Unit tests
+ */
+describe('Text Search Plugin:', () => {
+	describe('textSearch:', () => {
+		it('should add textSearch function to query', () => {
+			const query = TextExample.find();
+			should.exist(query.textSearch);
+
+			query.textSearch.should.be.Function();
+		});
+
+		it('should not add to filter/options if search term is null/undefined/empty string', () => {
+			[null, undefined, ''].forEach((search) => {
+				const query = TextExample.find().textSearch(search);
+
+				const filter = query.getFilter();
+				should.exist(filter);
+				should.not.exist(filter.$text);
+				should.not.exist(query.projection());
+
+				const options = query.getOptions();
+				should.exist(options);
+				should.not.exist(options.sort);
+			});
+		});
+
+		it('should update query filter/options', () => {
+			const query = TextExample.find().textSearch('test');
+
+			const filter = query.getFilter();
+			should.exist(filter);
+			should.exist(filter.$text);
+			filter.should.containEql({ $text: { $search: 'test' } });
+
+			should.exist(query.projection());
+			query.projection().should.containEql({ score: { $meta: 'textScore' } });
+
+			const options = query.getOptions();
+			should.exist(options);
+			should.exist(options.sort);
+			options.sort.should.containEql({ score: { $meta: 'textScore' } });
+		});
+	});
+});

--- a/src/app/common/mongoose/types.d.ts
+++ b/src/app/common/mongoose/types.d.ts
@@ -1,0 +1,16 @@
+export interface TextSearchPlugin {
+	textSearch(search: string);
+}
+
+export interface ContainsSearchPlugin {
+	containsSearch(search: string, fields?: string[]);
+}
+
+export interface PaginatePlugin {
+	paginate(
+		pageSize: number,
+		pageNumber: number,
+		runCount: boolean,
+		countTimeout: number
+	);
+}

--- a/src/app/common/util.service.js
+++ b/src/app/common/util.service.js
@@ -400,6 +400,9 @@ module.exports.submitPostRequest = (httpOpts, postBody) => {
 	});
 };
 
+/**
+ * @deprecated
+ */
 module.exports.getPagingResults = (
 	pageSize = 20,
 	pageNumber = 0,

--- a/src/app/common/util.service.js
+++ b/src/app/common/util.service.js
@@ -229,14 +229,14 @@ module.exports.getSort = function (
  * Get the sort provided by the user, if there is one.
  *
  * @param {Object} queryParams
+ * @param {'ASC' | 'DESC'} [defaultDir=ASC] (optional) default: ASC
  * @param {string} [defaultSort=undefined] (optional)
- * @param {string} [defaultDir=ASC] (optional) default: ASC
  * @returns {Object|null}
  */
 module.exports.getSortObj = function (
 	queryParams,
-	defaultSort,
-	defaultDir = 'ASC'
+	defaultDir = 'ASC',
+	defaultSort = undefined
 ) {
 	const sort = _.get(queryParams, 'sort', defaultSort);
 	const dir = _.get(queryParams, 'dir', defaultDir);

--- a/src/app/common/util.service.js
+++ b/src/app/common/util.service.js
@@ -226,6 +226,28 @@ module.exports.getSort = function (
 };
 
 /**
+ * Get the sort provided by the user, if there is one.
+ *
+ * @param {Object} queryParams
+ * @param {string} [defaultSort=undefined] (optional)
+ * @param {string} [defaultDir=ASC] (optional) default: ASC
+ * @returns {Object|null}
+ */
+module.exports.getSortObj = function (
+	queryParams,
+	defaultSort,
+	defaultDir = 'ASC'
+) {
+	const sort = _.get(queryParams, 'sort', defaultSort);
+	const dir = _.get(queryParams, 'dir', defaultDir);
+	if (!sort) {
+		return null;
+	}
+
+	return { [sort]: dir };
+};
+
+/**
  * Extract given field from request header
  */
 module.exports.getHeaderField = function (header, fieldName) {

--- a/src/app/common/util.service.spec.js
+++ b/src/app/common/util.service.spec.js
@@ -343,8 +343,9 @@ describe('Utils:', () => {
 			it(test.name, () => {
 				const actual = util.getSortObj(
 					test.input,
-					test.defaultSort,
-					test.defaultDir
+					// @ts-ignore
+					test.defaultDir,
+					test.defaultSort
 				);
 				should.exist(actual);
 				actual.should.containEql(test.expected);

--- a/src/app/common/util.service.spec.js
+++ b/src/app/common/util.service.spec.js
@@ -290,6 +290,68 @@ describe('Utils:', () => {
 		});
 	});
 
+	describe('getSortObj:', () => {
+		[
+			{
+				input: null,
+				expected: null,
+				name: 'should return null for null params '
+			},
+			{
+				input: {},
+				expected: null,
+				name: 'should return null for empty params'
+			}
+		].forEach((test) => {
+			it(test.name, () => {
+				const actual = util.getSortObj(test.input);
+				should(actual).equal(test.expected);
+			});
+		});
+
+		[
+			{
+				input: { sort: 'field1', dir: 'DESC' },
+				expected: { field1: 'DESC' },
+				name: 'should create sort array from request parameters'
+			},
+			{
+				input: { sort: 'field1' },
+				expected: { field1: 'ASC' },
+				name: 'should use default sort'
+			},
+			{
+				input: { sort: 'field1' },
+				defaultDir: 'DESC',
+				expected: { field1: 'DESC' },
+				name: 'should use override default dir'
+			},
+			{
+				input: {},
+				defaultSort: 'field1',
+				expected: { field1: 'ASC' },
+				name: 'should use override default sort'
+			},
+			{
+				input: {},
+				defaultDir: 'DESC',
+				defaultSort: 'field1',
+				expected: { field1: 'DESC' },
+				name: 'should use override default sort and dir'
+			}
+		].forEach((test) => {
+			it(test.name, () => {
+				const actual = util.getSortObj(
+					test.input,
+					test.defaultSort,
+					test.defaultDir
+				);
+				should.exist(actual);
+				actual.should.containEql(test.expected);
+			});
+		});
+	});
+
 	describe('contains:', () => {
 		[
 			{

--- a/src/app/core/access-checker/access-checker.controller.js
+++ b/src/app/core/access-checker/access-checker.controller.js
@@ -47,7 +47,6 @@ exports.matchEntries = async (req, res) => {
 	const page = util.getPage(req.query);
 	const limit = util.getLimit(req.query);
 	const sort = util.getSortObj(req.query);
-	const offset = page * limit;
 
 	try {
 		const results = await CacheEntry.find(query)

--- a/src/app/core/access-checker/cache/cache-entry.model.js
+++ b/src/app/core/access-checker/cache/cache-entry.model.js
@@ -2,7 +2,9 @@
 
 const mongoose = require('mongoose'),
 	getterPlugin = require('../../../common/mongoose/getter.plugin'),
-	pagingSearchPlugin = require('../../../common/mongoose/paging-search.plugin'),
+	paginatePlugin = require('../../../common/mongoose/paginate.plugin'),
+	containsSearchPlugin = require('../../../common/mongoose/contains-search.plugin'),
+	textSearchPlugin = require('../../../common/mongoose/text-search.plugin'),
 	deps = require('../../../../dependencies'),
 	util = deps.utilService;
 
@@ -33,7 +35,11 @@ const CacheEntrySchema = new mongoose.Schema({
 });
 
 CacheEntrySchema.plugin(getterPlugin);
-CacheEntrySchema.plugin(pagingSearchPlugin);
+CacheEntrySchema.plugin(paginatePlugin);
+CacheEntrySchema.plugin(containsSearchPlugin, {
+	fields: ['key', 'valueString']
+});
+CacheEntrySchema.plugin(textSearchPlugin);
 
 /**
  * Index declarations

--- a/src/app/core/audit/audit.controller.js
+++ b/src/app/core/audit/audit.controller.js
@@ -31,22 +31,17 @@ exports.search = async function (req, res) {
 
 	const page = util.getPage(req.query);
 	const limit = util.getLimit(req.query);
-	const sortArr = util.getSort(req.query, 'DESC', '_id');
-	const offset = page * limit;
+	const sort = util.getSortObj(req.query, 'DESC', '_id');
 
 	try {
-		const result = await Audit.containsSearch(
-			query,
-			['message', 'audit.auditType', 'audit.action', 'audit.object'],
-			search,
-			limit,
-			offset,
-			sortArr
-		);
+		const result = await Audit.find(query)
+			.containsSearch(search)
+			.sort(sort)
+			.paginate(limit, page);
 
 		// If any audit objects are strings, try to parse them as json. we may have stringified objects because mongo
 		// can't support keys with dots
-		const results = result.results.map((doc) => {
+		result.elements = result.elements.map((doc) => {
 			if (_.isString(doc.audit.object)) {
 				try {
 					doc.audit.object = JSON.parse(doc.audit.object);
@@ -59,11 +54,8 @@ exports.search = async function (req, res) {
 			return doc;
 		});
 
-		// success
-		const toReturn = util.getPagingResults(limit, page, result.count, results);
-
 		// Serialize the response
-		res.status(200).json(toReturn);
+		res.status(200).json(result);
 	} catch (err) {
 		// failure
 		logger.error({ err: err, req: req }, 'Error searching for audit entries');

--- a/src/app/core/audit/audit.model.js
+++ b/src/app/core/audit/audit.model.js
@@ -2,7 +2,8 @@
 
 const mongoose = require('mongoose'),
 	getterPlugin = require('../../common/mongoose/getter.plugin'),
-	pagingSearchPlugin = require('../../common/mongoose/paging-search.plugin'),
+	paginatePlugin = require('../../common/mongoose/paginate.plugin'),
+	containsSearchPlugin = require('../../common/mongoose/contains-search.plugin'),
 	deps = require('../../../dependencies'),
 	util = deps.utilService;
 
@@ -34,7 +35,10 @@ const AuditSchema = new mongoose.Schema({
 });
 
 AuditSchema.plugin(getterPlugin);
-AuditSchema.plugin(pagingSearchPlugin);
+AuditSchema.plugin(paginatePlugin);
+AuditSchema.plugin(containsSearchPlugin, {
+	fields: ['message', 'audit.auditType', 'audit.action', 'audit.object']
+});
 
 /**
  * Index declarations

--- a/src/app/core/feedback/feedback.model.js
+++ b/src/app/core/feedback/feedback.model.js
@@ -2,7 +2,8 @@
 
 const mongoose = require('mongoose'),
 	getterPlugin = require('../../common/mongoose/getter.plugin'),
-	pagingSearchPlugin = require('../../common/mongoose/paging-search.plugin'),
+	paginatePlugin = require('../../common/mongoose/paginate.plugin'),
+	textSearchPlugin = require('../../common/mongoose/text-search.plugin'),
 	deps = require('../../../dependencies'),
 	util = deps.utilService;
 
@@ -41,7 +42,8 @@ const FeedbackSchema = new mongoose.Schema({
 });
 
 FeedbackSchema.plugin(getterPlugin);
-FeedbackSchema.plugin(pagingSearchPlugin);
+FeedbackSchema.plugin(paginatePlugin);
+FeedbackSchema.plugin(textSearchPlugin);
 
 /**
  * Index declarations

--- a/src/app/core/feedback/feedback.service.js
+++ b/src/app/core/feedback/feedback.service.js
@@ -61,37 +61,28 @@ const create = async (reqUser, newFeedback, userSpec) => {
 	}
 };
 
-const search = async (reqUser, queryParams, query) => {
+const search = (reqUser, queryParams, search, query) => {
 	query = query || {};
 	const page = util.getPage(queryParams);
 	const limit = util.getLimit(queryParams, 100);
-	const sortArr = util.getSort(queryParams);
-	const offset = page * limit;
+	const sort = util.getSortObj(queryParams);
 
 	// Query for feedback
-	const feedback = await Feedback.textSearch(
-		query,
-		null,
-		limit,
-		offset,
-		sortArr,
-		true,
-		{
+	return Feedback.find(query)
+		.textSearch(search)
+		.sort(sort)
+		.populate({
 			path: 'creator',
 			select: ['username', 'organization', 'name', 'email']
-		}
-	);
-
-	return util.getPagingResults(limit, page, feedback.count, feedback.results);
+		})
+		.paginate(limit, page);
 };
 
 const readFeedback = async (feedbackId, populate = []) => {
 	if (!mongoose.Types.ObjectId.isValid(feedbackId)) {
 		throw { status: 400, type: 'validation', message: 'Invalid feedback ID' };
 	}
-	const feedback = await Feedback.findOne({
-		_id: feedbackId
-	})
+	const feedback = await Feedback.findById(feedbackId)
 		.populate(populate)
 		.exec();
 	return feedback;

--- a/src/app/core/messages/message.model.js
+++ b/src/app/core/messages/message.model.js
@@ -3,7 +3,8 @@
 const _ = require('lodash'),
 	mongoose = require('mongoose'),
 	getterPlugin = require('../../common/mongoose/getter.plugin'),
-	pagingSearchPlugin = require('../../common/mongoose/paging-search.plugin'),
+	paginatePlugin = require('../../common/mongoose/paginate.plugin'),
+	textSearchPlugin = require('../../common/mongoose/text-search.plugin'),
 	deps = require('../../../dependencies'),
 	dbs = deps.dbs,
 	config = deps.config,
@@ -48,7 +49,8 @@ const MessageSchema = new mongoose.Schema({
 	}
 });
 MessageSchema.plugin(getterPlugin);
-MessageSchema.plugin(pagingSearchPlugin);
+MessageSchema.plugin(paginatePlugin);
+MessageSchema.plugin(textSearchPlugin);
 
 const DismissedMessageSchema = new mongoose.Schema({
 	messageId: {

--- a/src/app/core/teams/team.model.js
+++ b/src/app/core/teams/team.model.js
@@ -3,7 +3,8 @@
 const _ = require('lodash'),
 	mongoose = require('mongoose'),
 	getterPlugin = require('../../common/mongoose/getter.plugin'),
-	pagingSearchPlugin = require('../../common/mongoose/paging-search.plugin'),
+	paginatePlugin = require('../../common/mongoose/paginate.plugin'),
+	textSearchPlugin = require('../../common/mongoose/text-search.plugin'),
 	deps = require('../../../dependencies'),
 	dbs = deps.dbs,
 	util = deps.utilService,
@@ -93,7 +94,8 @@ const TeamSchema = new mongoose.Schema({
 	}
 });
 TeamSchema.plugin(getterPlugin);
-TeamSchema.plugin(pagingSearchPlugin);
+TeamSchema.plugin(paginatePlugin);
+TeamSchema.plugin(textSearchPlugin);
 
 /**
  * Index declarations

--- a/src/app/core/user/eua/eua.model.js
+++ b/src/app/core/user/eua/eua.model.js
@@ -2,7 +2,8 @@
 
 const mongoose = require('mongoose'),
 	getterPlugin = require('../../../common/mongoose/getter.plugin'),
-	pagingSearchPlugin = require('../../../common/mongoose/paging-search.plugin'),
+	paginatePlugin = require('../../../common/mongoose/paginate.plugin'),
+	textSearchPlugin = require('../../../common/mongoose/text-search.plugin'),
 	deps = require('../../../../dependencies'),
 	util = deps.utilService;
 
@@ -37,7 +38,8 @@ const UserAgreementSchema = new mongoose.Schema({
 	}
 });
 UserAgreementSchema.plugin(getterPlugin);
-UserAgreementSchema.plugin(pagingSearchPlugin);
+UserAgreementSchema.plugin(paginatePlugin);
+UserAgreementSchema.plugin(textSearchPlugin);
 
 /**
  * Index declarations

--- a/src/app/core/user/eua/eua.service.js
+++ b/src/app/core/user/eua/eua.service.js
@@ -31,7 +31,7 @@ const remove = (eua) => {
 	return eua.remove();
 };
 
-const search = async (queryParams, query, _search) => {
+const search = (queryParams, query, _search) => {
 	query = query || {};
 	const page = util.getPage(queryParams);
 	const limit = util.getLimit(queryParams);

--- a/src/app/core/user/eua/eua.service.js
+++ b/src/app/core/user/eua/eua.service.js
@@ -35,19 +35,12 @@ const search = async (queryParams, query, _search) => {
 	query = query || {};
 	const page = util.getPage(queryParams);
 	const limit = util.getLimit(queryParams);
-	const sortArr = util.getSort(queryParams, 'DESC');
-	const offset = page * limit;
+	const sort = util.getSortObj(queryParams, 'DESC');
 
-	const euas = await UserAgreement.textSearch(
-		query,
-		_search,
-		limit,
-		offset,
-		sortArr,
-		true
-	);
-
-	return util.getPagingResults(limit, page, euas.count, euas.results);
+	return UserAgreement.find(query)
+		.textSearch(_search)
+		.sort(sort)
+		.paginate(limit, page);
 };
 
 const publishEua = (eua) => {

--- a/src/app/core/user/user.model.js
+++ b/src/app/core/user/user.model.js
@@ -8,7 +8,9 @@ const _ = require('lodash'),
 	config = deps.config,
 	util = deps.utilService,
 	getterPlugin = require('../../common/mongoose/getter.plugin'),
-	pagingSearchPlugin = require('../../common/mongoose/paging-search.plugin');
+	paginatePlugin = require('../../common/mongoose/paginate.plugin'),
+	containsSearchPlugin = require('../../common/mongoose/contains-search.plugin'),
+	textSearchPlugin = require('../../common/mongoose/text-search.plugin');
 
 /**
  * Validation
@@ -238,7 +240,9 @@ const UserSchema = new mongoose.Schema({
 });
 UserSchema.plugin(getterPlugin);
 UserSchema.plugin(uniqueValidator);
-UserSchema.plugin(pagingSearchPlugin);
+UserSchema.plugin(paginatePlugin);
+UserSchema.plugin(containsSearchPlugin);
+UserSchema.plugin(textSearchPlugin);
 
 /**
  * Index declarations

--- a/src/app/core/user/user.service.js
+++ b/src/app/core/user/user.service.js
@@ -26,7 +26,7 @@ const remove = (user) => {
 	return user.remove();
 };
 
-const searchUsers = async (queryParams, query, search, searchFields = []) => {
+const searchUsers = (queryParams, query, search, searchFields = []) => {
 	query = query || {};
 	const page = util.getPage(queryParams);
 	const limit = util.getLimit(queryParams);

--- a/src/app/core/user/user.service.js
+++ b/src/app/core/user/user.service.js
@@ -30,24 +30,17 @@ const searchUsers = async (queryParams, query, search, searchFields = []) => {
 	query = query || {};
 	const page = util.getPage(queryParams);
 	const limit = util.getLimit(queryParams);
-	const sortArr = util.getSort(queryParams, 'DESC');
-	const offset = page * limit;
+	const sort = util.getSortObj(queryParams, 'DESC');
 
-	let result;
+	let mQuery = User.find(query);
+
 	if (searchFields.length > 0) {
-		result = await User.containsSearch(
-			query,
-			searchFields,
-			search,
-			limit,
-			offset,
-			sortArr
-		);
+		mQuery = mQuery.containsSearch(search, searchFields);
 	} else {
-		result = await User.textSearch(query, search, limit, offset, sortArr);
+		mQuery = mQuery.textSearch(search);
 	}
 
-	return util.getPagingResults(limit, page, result.count, result.results);
+	return mQuery.sort(sort).paginate(limit, page);
 };
 
 module.exports = {


### PR DESCRIPTION
…e/textSearch/containsSearch plugins

The current paging-search plugin couples paging and search logic together.  This was problematic when creating an export as the search logic had to be duplicated.
This replace the current paging-search plugin with 3 separate plugins.

These new plugins using [mongoose query helpers](https://mongoosejs.com/docs/guide.html#query-helpers) to extend mongoose's chainable query builder API.