### PR TITLE
fix: only use eslintignore.

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,8 +1,11 @@
 # Ignore artifacts
+.nyc_output/
 build
 coverage
-.vscode
 
 # Configs
 config
 node_modules
+
+# IDE/Editor config
+.vscode/

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "lint:fix": "npm run lint:eslint:fix",
     "lint:eslint": "eslint \"./**/*.js\"",
     "lint:eslint:fix": "eslint \"./**/*.js\" --fix",
-    "tsc:check": "./node_modules/typescript/bin/tsc --project tsconfig.json --noEmit",
+    "tsc:check": "tsc --project tsconfig.json --noEmit",
     "tsc:watch": "tsc --watch --noEmit"
   },
   "nyc": {


### PR DESCRIPTION
I think when we first included prettier, we threw in a prettierignore file-- now that our scripts have been trimmed to only defer to prettier for fixes through eslint, we no longer need the prettierignore file at all.

1. Removed prettierignore file in favour of using eslintignore.
2. Extended the eslintignore file a bit to exclude some output.
3. Updated package.json tsc script to use `tsc` instead of direct path into node_modules.

Note: If you build a dockerfile from this, make sure you include the .eslintignore file if you are going to use npm run start to serve the application to ensure that eslint doesn't have a fit with any production configurations that are generated at deployment time.