### PR TITLE
fix(teams): Misc fixes and refactors of team.service

### DIFF
--- a/src/app/core/resources/resources.service.js
+++ b/src/app/core/resources/resources.service.js
@@ -95,10 +95,6 @@ function searchResources(query, queryParams, user) {
 	// If user is not an admin, constrain the results to the user's teams
 	if (null == user.roles || !user.roles.admin) {
 		searchPromise = teamsService.getMemberTeamIds(user).then((teamIds) => {
-			teamIds = teamIds.map((teamId) =>
-				_.isString(teamId) ? mongoose.Types.ObjectId(teamId) : teamId
-			);
-
 			query.$or = [
 				{ 'owner.type': 'team', 'owner._id': { $in: teamIds } },
 				{ 'owner.type': 'user', 'owner._id': user._id }
@@ -139,10 +135,7 @@ async function constrainTagResults(teamId, user) {
 	}
 	if (null == user.roles || !user.roles.admin) {
 		// If user is not admin, constrain results to user's teams
-		let teamIds = await teamsService.getMemberTeamIds(user);
-		teamIds = teamIds.map((_teamId) =>
-			_.isString(_teamId) ? mongoose.Types.ObjectId(_teamId) : _teamId
-		);
+		const teamIds = await teamsService.getMemberTeamIds(user);
 
 		return {
 			$or: [
@@ -252,10 +245,6 @@ function filterResourcesByAccess(ids, user) {
 			.getMemberTeamIds(user)
 			.then((teamIds) => {
 				// Get teams user has belongs to
-				teamIds = teamIds.map((teamId) =>
-					_.isString(teamId) ? mongoose.Types.ObjectId(teamId) : teamId
-				);
-
 				const query = {
 					$and: [
 						{ _id: { $in: ids } },

--- a/src/app/core/teams/teams.service.js
+++ b/src/app/core/teams/teams.service.js
@@ -805,7 +805,12 @@ const updateTeams = async (user) => {
 	user.teams = updatedTeams;
 };
 
-const isObjectIdEqual = (value1, value2) => value1.equals(value2);
+const isObjectIdEqual = (value1, value2) => {
+	if (value1 == null) {
+		return false;
+	}
+	return value1.equals(value2);
+};
 
 module.exports = {
 	createTeam,

--- a/src/app/core/teams/teams.service.js
+++ b/src/app/core/teams/teams.service.js
@@ -357,7 +357,7 @@ const searchTeams = async (queryParams, query, search, user) => {
 
 		// If the query already has a filter by team, take the intersection
 		if (null != query._id && null != query._id.$in) {
-			teamIds = _.intersectionBy(teamIds, query._id.$in, (i) => i.toString());
+			teamIds = _.intersectionWith(teamIds, query._id.$in, isObjectIdEqual);
 		}
 
 		// If no remaining teams, return no results
@@ -589,6 +589,11 @@ const requestNewTeam = async (org, aoi, description, requester, req) => {
 	}
 };
 
+/**
+ * @param user
+ * @param {...string} roles
+ * @returns {Promise<mongoose.Types.ObjectId[]>}
+ */
 const getExplicitTeamIds = (user, ...roles) => {
 	// Validate the user input
 	if (null == user) {
@@ -610,13 +615,17 @@ const getExplicitTeamIds = (user, ...roles) => {
 		);
 	}
 
-	const userTeamIds = userTeams.map((t) => t._id.toString());
+	// const userTeamIds = userTeams.map((t) => t._id.toString());
+	const userTeamIds = userTeams.map((t) => t._id);
 
 	return Promise.resolve(userTeamIds);
 };
 
 /**
- * Team authorization Middleware
+ *
+ * @param user
+ * @param {...string} roles
+ * @returns {Promise<mongoose.Types.ObjectId[]>}
  */
 const getImplicitTeamIds = (user, ...roles) => {
 	// Validate the user input
@@ -628,6 +637,9 @@ const getImplicitTeamIds = (user, ...roles) => {
 		});
 	}
 
+	/**
+	 * @type {string | null}
+	 */
 	const strategy = _.get(config, 'teams.implicitMembers.strategy', null);
 
 	if (strategy == null || (roles.length > 0 && !roles.includes('member'))) {
@@ -681,42 +693,74 @@ const getImplicitTeamIds = (user, ...roles) => {
 	return Team.distinct('_id', query).exec();
 };
 
-const getNestedTeamIds = async (teamIds = []) => {
+/**
+ * @param {mongoose.Types.ObjectId[]} teamIds
+ * @returns {Promise<mongoose.Types.ObjectId[]>}
+ */
+const getNestedTeamIds = (teamIds = []) => {
 	const nestedTeamsEnabled = _.get(config, 'teams.nestedTeams', false);
 	if (!nestedTeamsEnabled || teamIds.length === 0) {
 		return Promise.resolve([]);
 	}
 
-	const mappedTeamIds = teamIds.map((teamId) =>
-		_.isString(teamId) ? mongoose.Types.ObjectId(teamId) : teamId
-	);
-
-	return await Team.distinct('_id', {
-		_id: { $nin: mappedTeamIds },
-		ancestors: { $in: mappedTeamIds }
+	return Team.distinct('_id', {
+		_id: { $nin: teamIds },
+		ancestors: { $in: teamIds }
 	}).exec();
 };
 
+/**
+ * @param {mongoose.Types.ObjectId[]} teamIds
+ * @returns {Promise<mongoose.Types.ObjectId[]>}
+ */
+const getAncestorTeamIds = (teamIds = []) => {
+	return Team.distinct('ancestors', { _id: { $in: teamIds } }).exec();
+};
+
+/**
+ * @param user
+ * @param {...string} roles
+ * @returns {Promise<mongoose.Types.ObjectId[]>}
+ */
 const getTeamIds = async (user, ...roles) => {
 	const explicitTeamIds = await getExplicitTeamIds(user, ...roles);
 	const implicitTeamIds = await getImplicitTeamIds(user, ...roles);
 	const nestedTeamIds = await getNestedTeamIds([
-		...explicitTeamIds,
-		...implicitTeamIds
+		...new Set([...explicitTeamIds, ...implicitTeamIds])
 	]);
 
-	return [...explicitTeamIds, ...implicitTeamIds, ...nestedTeamIds];
+	return [
+		...new Set([...explicitTeamIds, ...implicitTeamIds, ...nestedTeamIds])
+	];
 };
 
+/**
+ * @param user
+ * @returns {Promise<mongoose.Types.ObjectId[]>}
+ */
 const getMemberTeamIds = (user) =>
 	getTeamIds(user, 'member', 'editor', 'admin');
 
+/**
+ * @param user
+ * @returns {Promise<mongoose.Types.ObjectId[]>}
+ */
 const getEditorTeamIds = (user) => getTeamIds(user, 'editor', 'admin');
 
+/**
+ * @param user
+ * @returns {Promise<mongoose.Types.ObjectId[]>}
+ */
 const getAdminTeamIds = (user) => getTeamIds(user, 'admin');
 
-// Constrain a set of teamIds provided by the user to those the user actually has access to.
-const filterTeamIds = async (user, teamIds) => {
+/**
+ * Constrain a set of teamIds provided by the user to those the user actually has access to.
+ *
+ * @param user
+ * @param {mongoose.Types.ObjectId[]} [teamIds]
+ * @returns {Promise<mongoose.Types.ObjectId[]>}
+ */
+const filterTeamIds = async (user, teamIds = []) => {
 	const memberTeamIds = await getMemberTeamIds(user);
 
 	// If there were no teamIds to filter by, return all the team ids
@@ -724,7 +768,7 @@ const filterTeamIds = async (user, teamIds) => {
 		return memberTeamIds;
 	}
 	// Else, return the intersection of the two
-	return _.intersection(memberTeamIds, teamIds);
+	return _.intersectionWith(memberTeamIds, teamIds, isObjectIdEqual);
 };
 
 const updateTeams = async (user) => {
@@ -741,8 +785,16 @@ const updateTeams = async (user) => {
 		getTeamIds(user, 'member')
 	]);
 
-	const filteredEditorTeamIds = _.difference(editorTeamIds, adminTeamIds);
-	const filteredMemberTeamIds = _.difference(memberTeamIds, editorTeamIds);
+	const filteredEditorTeamIds = _.differenceWith(
+		editorTeamIds,
+		adminTeamIds,
+		isObjectIdEqual
+	);
+	const filteredMemberTeamIds = _.differenceWith(
+		memberTeamIds,
+		[...editorTeamIds, ...adminTeamIds],
+		isObjectIdEqual
+	);
 
 	const updatedTeams = [
 		...adminTeamIds.map((id) => ({ role: 'admin', _id: id })),
@@ -752,6 +804,8 @@ const updateTeams = async (user) => {
 
 	user.teams = updatedTeams;
 };
+
+const isObjectIdEqual = (value1, value2) => value1.equals(value2);
 
 module.exports = {
 	createTeam,
@@ -774,6 +828,7 @@ module.exports = {
 	getExplicitTeamIds,
 	getImplicitTeamIds,
 	getNestedTeamIds,
+	getAncestorTeamIds,
 	getTeamIds,
 	getMemberTeamIds,
 	getEditorTeamIds,

--- a/src/app/core/teams/teams.service.spec.js
+++ b/src/app/core/teams/teams.service.spec.js
@@ -1334,6 +1334,30 @@ describe('Team Service:', () => {
 			});
 		});
 
+		describe('getAncestorTeamIds', () => {
+			it('should return team ancestors', async () => {
+				const ancestors = await teamsService.getAncestorTeamIds([
+					team.nestedTeam2_1._id
+				]);
+				ancestors.should.deepEqual([
+					team.teamWithNoExternalTeam._id,
+					team.nestedTeam2._id
+				]);
+			});
+
+			it('should return empty array for team without ancestors', async () => {
+				const ancestors = await teamsService.getAncestorTeamIds([
+					team.teamWithNoExternalTeam._id
+				]);
+				ancestors.should.deepEqual([]);
+			});
+
+			it('should return empty array when no teams are passed in', async () => {
+				const ancestors = await teamsService.getAncestorTeamIds();
+				ancestors.should.deepEqual([]);
+			});
+		});
+
 		describe('updateTeams', () => {
 			it('implicit members disabled; nested teams disabled', async () => {
 				sandbox.stub(deps.config.teams, 'implicitMembers').value({});
@@ -1385,7 +1409,7 @@ describe('Team Service:', () => {
 				};
 				await teamsService.updateTeams(user);
 
-				user.teams.length.should.equal(12);
+				user.teams.length.should.equal(7);
 			});
 
 			it('implicit members enabled; nested teams enabled', async () => {
@@ -1404,7 +1428,7 @@ describe('Team Service:', () => {
 				};
 				await teamsService.updateTeams(user);
 
-				user.teams.length.should.equal(13);
+				user.teams.length.should.equal(8);
 			});
 		});
 	});
@@ -1520,23 +1544,23 @@ describe('Team Service:', () => {
 		const _user = {
 			teams: [
 				{
-					_id: '000000000000000000000001',
+					_id: mongoose.Types.ObjectId('000000000000000000000001'),
 					role: 'member'
 				},
 				{
-					_id: '000000000000000000000002',
+					_id: mongoose.Types.ObjectId('000000000000000000000002'),
 					role: 'member'
 				},
 				{
-					_id: '000000000000000000000003',
+					_id: mongoose.Types.ObjectId('000000000000000000000003'),
 					role: 'editor'
 				},
 				{
-					_id: '000000000000000000000004',
+					_id: mongoose.Types.ObjectId('000000000000000000000004'),
 					role: 'admin'
 				},
 				{
-					_id: '000000000000000000000005',
+					_id: mongoose.Types.ObjectId('000000000000000000000005'),
 					role: 'editor'
 				}
 			]
@@ -1544,27 +1568,27 @@ describe('Team Service:', () => {
 
 		it('should filter teamIds for membership (basic)', async () => {
 			const teamIds = await teamsService.filterTeamIds(_user, [
-				'000000000000000000000001'
+				mongoose.Types.ObjectId('000000000000000000000001')
 			]);
 			should.exist(teamIds);
 			teamIds.should.have.length(1);
-			should(teamIds[0]).equal('000000000000000000000001');
+			should(teamIds[0].toString()).equal('000000000000000000000001');
 		});
 
 		it('should filter teamIds for membership (advanced)', async () => {
 			const teamIds = await teamsService.filterTeamIds(_user, [
-				'000000000000000000000001',
-				'000000000000000000000002'
+				mongoose.Types.ObjectId('000000000000000000000001'),
+				mongoose.Types.ObjectId('000000000000000000000002')
 			]);
 			should.exist(teamIds);
 			teamIds.should.have.length(2);
-			should(teamIds[0]).equal('000000000000000000000001');
-			should(teamIds[1]).equal('000000000000000000000002');
+			should(teamIds[0].toString()).equal('000000000000000000000001');
+			should(teamIds[1].toString()).equal('000000000000000000000002');
 		});
 
 		it('should filter teamIds for membership when no access', async () => {
 			const teamIds = await teamsService.filterTeamIds(_user, [
-				'000000000000000000000006'
+				mongoose.Types.ObjectId('000000000000000000000006')
 			]);
 			should.exist(teamIds);
 			teamIds.should.have.length(0);
@@ -1574,11 +1598,11 @@ describe('Team Service:', () => {
 			const teamIds = await teamsService.filterTeamIds(_user);
 			should.exist(teamIds);
 			teamIds.should.have.length(5);
-			should(teamIds[0]).equal('000000000000000000000001');
-			should(teamIds[1]).equal('000000000000000000000002');
-			should(teamIds[2]).equal('000000000000000000000003');
-			should(teamIds[3]).equal('000000000000000000000004');
-			should(teamIds[4]).equal('000000000000000000000005');
+			should(teamIds[0].toString()).equal('000000000000000000000001');
+			should(teamIds[1].toString()).equal('000000000000000000000002');
+			should(teamIds[2].toString()).equal('000000000000000000000003');
+			should(teamIds[3].toString()).equal('000000000000000000000004');
+			should(teamIds[4].toString()).equal('000000000000000000000005');
 		});
 	});
 });


### PR DESCRIPTION
* Add getAncestors method
* Added jsdoc type definitions to various methods.
* Now enforcing ObjectId type when specifying team ids.  Previously supported string or object id with conversions.  Discovered that the conversions weren't always happening where needed.  Safer to just enforce type.  Discovered and fixed some bugs due to this that tests did not catch.