### PR TITLE
fix(audit): Audit schema/index fixes

### DIFF
--- a/src/app/core/audit/audit.model.js
+++ b/src/app/core/audit/audit.model.js
@@ -9,6 +9,9 @@ const mongoose = require('mongoose'),
 
 /**
  * Schema Declaration
+ *
+ * @typed {mongoose.Schema<import('./types').AuditDocument, import('./types').AuditModel>}
+ * @type {mongoose.Schema}
  */
 const AuditSchema = new mongoose.Schema({
 	created: {
@@ -18,18 +21,13 @@ const AuditSchema = new mongoose.Schema({
 	},
 	message: { type: String },
 	audit: {
-		type: {
-			auditType: { type: String },
-			action: { type: String },
-			actor: { type: String },
-			interfaceUrl: { type: String },
-			object: { type: String },
-			userSpec: {
-				type: {
-					browser: { type: String },
-					os: { type: String }
-				}
-			}
+		auditType: { type: String },
+		action: { type: String },
+		actor: { type: Object },
+		object: { type: mongoose.Schema.Types.Mixed },
+		userSpec: {
+			browser: { type: String },
+			os: { type: String }
 		}
 	}
 });
@@ -37,7 +35,7 @@ const AuditSchema = new mongoose.Schema({
 AuditSchema.plugin(getterPlugin);
 AuditSchema.plugin(paginatePlugin);
 AuditSchema.plugin(containsSearchPlugin, {
-	fields: ['message', 'audit.auditType', 'audit.action', 'audit.object']
+	fields: ['message', 'audit.auditType', 'audit.action']
 });
 
 /**
@@ -53,11 +51,11 @@ AuditSchema.index({ 'audit.auditType': 1 });
 // Audit Action index
 AuditSchema.index({ 'audit.action': 1 });
 
-// User index
-AuditSchema.index({ 'audit.actor': 1 });
+// actor._id index
+AuditSchema.index({ 'audit.actor._id': 1 });
 
-// Audit object index
-AuditSchema.index({ 'audit.object': 1 });
+// actor.name index
+AuditSchema.index({ 'audit.actor.name': 1 });
 
 // Audit message index
 AuditSchema.index({ message: 1 });
@@ -73,4 +71,10 @@ AuditSchema.index({ message: 1 });
 /**
  * Register the Schema with Mongoose
  */
-mongoose.model('Audit', AuditSchema, 'audit');
+/**
+ *
+ * @type {import('./types').AuditModel}
+ */
+const Audit = mongoose.model('Audit', AuditSchema, 'audit');
+
+module.exports = Audit;

--- a/src/app/core/audit/audit.service.js
+++ b/src/app/core/audit/audit.service.js
@@ -1,60 +1,70 @@
 'use strict';
 
 const deps = require('../../../dependencies'),
-	dbs = deps.dbs,
 	logger = deps.logger,
 	auditLogger = deps.auditLogger;
 
-// Creates an audit entry persisted to Mongo and the bunyan logger
-module.exports.audit = function (
+/**
+ * Creates an audit entry persisted to Mongo and the bunyan logger
+ *
+ * @param {string} message
+ * @param {string} eventType
+ * @param {string} eventAction
+ * @param {* | Promise<*>} eventActor
+ * @param {*} eventObject
+ * @param {*} [eventMetadata]
+ * @param {boolean} [stringifyEventObject]
+ * @returns {Promise<import('./types').AuditDocument>}
+ */
+module.exports.audit = async (
 	message,
 	eventType,
 	eventAction,
 	eventActor,
 	eventObject,
-	eventMetadata,
-	stringifyEventObject
-) {
-	const Audit = dbs.admin.model('Audit');
+	eventMetadata = null,
+	stringifyEventObject = false
+) => {
+	const Audit = require('./audit.model');
 	const utilService = deps.utilService;
 
-	return Promise.resolve(eventActor).then((actor) => {
-		// Extract additional metadata to audit
-		const userAgentObj = utilService.getUserAgentFromHeader(eventMetadata);
+	const actor = await Promise.resolve(eventActor);
 
-		// Send to Mongo
-		const newAudit = new Audit({
-			created: Date.now(),
-			message: message,
-			audit: {
-				auditType: eventType,
-				action: eventAction,
-				actor: actor,
-				userSpec: userAgentObj
-			}
-		});
+	// Extract additional metadata to audit
+	const userAgentObj = utilService.getUserAgentFromHeader(eventMetadata);
 
-		newAudit.audit.object = stringifyEventObject
-			? JSON.stringify(eventObject)
-			: eventObject;
+	// Send to Mongo
+	const newAudit = new Audit({
+		created: Date.now(),
+		message: message,
+		audit: {
+			auditType: eventType,
+			action: eventAction,
+			actor: actor,
+			userSpec: userAgentObj
+		}
+	});
 
-		// Send to bunyan logger for logfile persistence
-		auditLogger.audit(
-			message,
-			eventType,
-			eventAction,
-			actor,
-			eventObject,
-			userAgentObj
+	newAudit.audit.object = stringifyEventObject
+		? JSON.stringify(eventObject)
+		: eventObject;
+
+	// Send to bunyan logger for logfile persistence
+	auditLogger.audit(
+		message,
+		eventType,
+		eventAction,
+		actor,
+		eventObject,
+		userAgentObj
+	);
+
+	return newAudit.save().catch((err) => {
+		// Log and continue the error
+		logger.error(
+			{ err: err, audit: newAudit },
+			'Error trying to persist audit record to storage.'
 		);
-
-		return newAudit.save().catch((err) => {
-			// Log and continue the error
-			logger.error(
-				{ err: err, audit: newAudit },
-				'Error trying to persist audit record to storage.'
-			);
-			return Promise.reject(err);
-		});
+		return Promise.reject(err);
 	});
 };

--- a/src/app/core/audit/audit.service.js
+++ b/src/app/core/audit/audit.service.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const deps = require('../../../dependencies'),
+	dbs = deps.dbs,
 	logger = deps.logger,
 	auditLogger = deps.auditLogger;
 
@@ -25,7 +26,10 @@ module.exports.audit = async (
 	eventMetadata = null,
 	stringifyEventObject = false
 ) => {
-	const Audit = require('./audit.model');
+	/**
+	 * @type {import('./types').AuditModel}
+	 */
+	const Audit = dbs.admin.model('Audit');
 	const utilService = deps.utilService;
 
 	const actor = await Promise.resolve(eventActor);

--- a/src/app/core/audit/types.d.ts
+++ b/src/app/core/audit/types.d.ts
@@ -1,0 +1,20 @@
+import { Document, Model } from 'mongoose';
+
+interface IAudit extends Document {
+	created: Date;
+	message: string;
+	audit: {
+		auditType: string;
+		action: string;
+		actor: Object;
+		object: string | Object;
+		userSpec: {
+			browser: string;
+			os: string;
+		};
+	};
+}
+
+export interface AuditDocument extends IAudit {}
+
+export interface AuditModel extends Model<AuditDocument> {}

--- a/src/lib/strategies/proxy-pki.js
+++ b/src/lib/strategies/proxy-pki.js
@@ -1,7 +1,6 @@
 'use strict';
 
 const _ = require('lodash'),
-	mongoose = require('mongoose'),
 	passport = require('passport'),
 	deps = require('../../dependencies'),
 	dbs = deps.dbs,


### PR DESCRIPTION
* Updated Audit schema to correctly represent what is being store.  `audit` property was being created with a SchemaType of Mixed.  This caused mongoose to skip all validation as Mixed can be anything.  `audit.object` property is now explicitly set as Mixed since it can be an Object or string.
* Updated Audit indexes to match how the audit collection is queried.  Removed `audit.object` index.  Replaced `audit.actor` index with `audit.actor._id` and `audit.actor.name` indexes.
* Added type definitions