### PR TITLE
refactor: Update mongoose plugins for improved type safety and usability

### DIFF
--- a/src/app/common/mongoose/contains-search.plugin.js
+++ b/src/app/common/mongoose/contains-search.plugin.js
@@ -25,11 +25,11 @@ const containsSearchPlugin = (schema, pluginOptions = {}) => {
 		}
 
 		if (fields.length === 1) {
-			return this.find({
+			return this.where({
 				[fields[0]]: { $regex: new RegExp(escapeRegex(search), 'gim') }
 			});
 		}
-		return this.find({
+		return this.where({
 			$or: fields.map((element) => ({
 				[element]: { $regex: new RegExp(escapeRegex(search), 'gim') }
 			}))

--- a/src/app/common/mongoose/text-search.plugin.js
+++ b/src/app/common/mongoose/text-search.plugin.js
@@ -11,7 +11,7 @@ const textSearchPlugin = (schema) => {
 			return this;
 		}
 
-		return this.find({ $text: { $search: search } })
+		return this.where({ $text: { $search: search } })
 			.select({
 				score: { $meta: 'textScore' }
 			})

--- a/src/app/common/mongoose/types.d.ts
+++ b/src/app/common/mongoose/types.d.ts
@@ -1,16 +1,26 @@
+import { Document } from 'mongoose';
+
+export interface PagingResults<DocType extends Document = Document> {
+	pageNumber: number;
+	pageSize: number;
+	totalPages: number;
+	totalSize: number;
+	elements: DocType[];
+}
+
 export interface TextSearchPlugin {
-	textSearch(search: string);
+	textSearch(search: string): this;
 }
 
 export interface ContainsSearchPlugin {
-	containsSearch(search: string, fields?: string[]);
+	containsSearch(search: string, fields?: string[]): this;
 }
 
-export interface PaginatePlugin {
+export interface PaginatePlugin<DocType extends Document> {
 	paginate(
 		pageSize: number,
 		pageNumber: number,
-		runCount: boolean,
-		countTimeout: number
-	);
+		runCount?: boolean,
+		countTimeout?: number
+	): Promise<PagingResults<DocType>>;
 }


### PR DESCRIPTION
* Updated search plugins to use `where` vs. `find` for adding query clause.  This allows them to be used with more query types (i.e. find, findOne, count, ...)
* Updated plugin type definitions to specify correct return types
* Updated paginate function definition to properly mark optional parameters