### PR TITLE
Ensuring User model from admin database

### DIFF
--- a/src/lib/strategies/proxy-pki.js
+++ b/src/lib/strategies/proxy-pki.js
@@ -10,7 +10,7 @@ const _ = require('lodash'),
 	userAuthService = require('../../app/core/user/auth/user-authentication.service'),
 	userEmailService = require('../../app/core/user/user-email.service'),
 	TeamMember = dbs.admin.model('TeamUser'),
-	User = require('../../app/core/user/user.model');
+	User = dbs.admin.model('User');
 
 class ProxyPkiStrategy extends passport.Strategy {
 	constructor(options, verify) {


### PR DESCRIPTION
By specifying the admin database for the User model, mongoose will guarantee that requests around that User model will use that connection vs. any other connections that may be provided in the database setup. This is also consistent with how we're loading the TeamUser model on the line above.