### PR TITLE
Expose team ancestor ids endpoint

### DIFF
--- a/src/app/core/teams/teams.controller.js
+++ b/src/app/core/teams/teams.controller.js
@@ -140,6 +140,15 @@ module.exports.search = async (req, res) => {
 	}
 };
 
+module.exports.getAncestorTeamIds = async (req, res) => {
+	try {
+		const result = await teamsService.getAncestorTeamIds(req.body.teamIds);
+		res.status(200).json(result);
+	} catch (err) {
+		util.handleErrorResponse(res, err);
+	}
+};
+
 module.exports.requestNewTeam = async (req, res) => {
 	const user = req.user;
 	const org = req.body.org || null;

--- a/src/app/core/teams/teams.routes.js
+++ b/src/app/core/teams/teams.routes.js
@@ -14,6 +14,8 @@ router.route('/team').put(user.hasEditorAccess, teams.create);
 
 router.route('/teams').post(user.hasAccess, teams.search);
 
+router.route('/team/ancestors').post(user.hasAccess, teams.getAncestorTeamIds);
+
 router
 	.route('/team/:teamId')
 	.get(


### PR DESCRIPTION
Added /team/ancestors POST route which accepts multiple teamIds and returns their ancestorTeamIds