### PR TITLE
add isMember field to the team's search results

### DIFF
--- a/src/app/core/teams/team.components.yml
+++ b/src/app/core/teams/team.components.yml
@@ -48,7 +48,6 @@ components:
             isMember:
               type: boolean
               description: Whether the user making the request is a member of the team or not
-              required: false
     TeamMember:
       type: object
       properties:

--- a/src/app/core/teams/team.components.yml
+++ b/src/app/core/teams/team.components.yml
@@ -45,6 +45,10 @@ components:
             creatorName:
               type: string
               description: Full display name of the user who created the team
+            isMember:
+              type: boolean
+              description: Whether the user making the request is a member of the team or not
+              required: false
     TeamMember:
       type: object
       properties:

--- a/src/app/core/teams/teams.service.spec.js
+++ b/src/app/core/teams/teams.service.spec.js
@@ -526,12 +526,12 @@ describe('Team Service:', () => {
 			);
 
 			should.exist(result);
-			result.totalSize.should.equal(100);
+			result.totalSize.should.equal(2);
 			result.pageSize.should.equal(queryParams.size);
 			result.pageNumber.should.equal(0);
 			result.totalPages.should.equal(1);
 			result.elements.should.be.an.Array();
-			result.elements.length.should.be.equal(queryParams.size);
+			result.elements.length.should.be.equal(2);
 
 			const isMemberResults = result.elements
 				.filter((element) => element.isMember)
@@ -550,12 +550,12 @@ describe('Team Service:', () => {
 			);
 
 			should.exist(result2);
-			result2.totalSize.should.equal(100);
+			result2.totalSize.should.equal(1);
 			result2.pageSize.should.equal(queryParams.size);
 			result2.pageNumber.should.equal(0);
 			result2.totalPages.should.equal(1);
 			result2.elements.should.be.an.Array();
-			result2.elements.length.should.be.equal(queryParams.size);
+			result2.elements.length.should.be.equal(1);
 
 			const isMemberResults2 = result2.elements
 				.filter((element) => element.isMember)

--- a/src/app/core/teams/teams.service.spec.js
+++ b/src/app/core/teams/teams.service.spec.js
@@ -95,6 +95,7 @@ describe('Team Service:', () => {
 
 	// Generic test users
 	spec.user.user1 = localUserSpec('user1');
+	spec.user.user1.roles = { user: 1 };
 	spec.userTeams.user1 = [
 		{ team: 'teamWithNoExternalTeam', role: 'member' },
 		{ team: 'teamWithNoExternalTeam2', role: 'member' }
@@ -103,6 +104,7 @@ describe('Team Service:', () => {
 	spec.user.user2 = localUserSpec('user2');
 
 	spec.user.user3 = localUserSpec('user3');
+	spec.user.user3.roles = { user: 1 };
 	spec.userTeams.user3 = [{ team: 'teamWithNoExternalTeam', role: 'admin' }];
 
 	spec.user.admin = localUserSpec('admin');
@@ -510,6 +512,58 @@ describe('Team Service:', () => {
 			result.totalPages.should.equal(1);
 			result.elements.should.be.an.Array();
 			result.elements.length.should.be.equal(1);
+		});
+
+		it('check isMember field', async () => {
+			const queryParams = { size: 100 };
+			const query = {};
+			const search = '';
+			const result = await teamsService.searchTeams(
+				queryParams,
+				query,
+				search,
+				user.user1
+			);
+
+			should.exist(result);
+			result.totalSize.should.equal(100);
+			result.pageSize.should.equal(queryParams.size);
+			result.pageNumber.should.equal(0);
+			result.totalPages.should.equal(1);
+			result.elements.should.be.an.Array();
+			result.elements.length.should.be.equal(queryParams.size);
+
+			const isMemberResults = result.elements
+				.filter((element) => element.isMember)
+				.map((team) => team.name);
+
+			// user 1 is only members of these two teams (defined by user setup above)
+			isMemberResults.length.should.equal(2);
+			isMemberResults[0].should.equal(team.teamWithNoExternalTeam2.name);
+			isMemberResults[1].should.equal(team.teamWithNoExternalTeam.name);
+
+			const result2 = await teamsService.searchTeams(
+				queryParams,
+				query,
+				search,
+				user.user3
+			);
+
+			should.exist(result2);
+			result2.totalSize.should.equal(100);
+			result2.pageSize.should.equal(queryParams.size);
+			result2.pageNumber.should.equal(0);
+			result2.totalPages.should.equal(1);
+			result2.elements.should.be.an.Array();
+			result2.elements.length.should.be.equal(queryParams.size);
+
+			const isMemberResults2 = result2.elements
+				.filter((element) => element.isMember)
+				.map((team) => team.name);
+
+			// user 3 is only members of one of these teams (defined by user setup above)
+			isMemberResults2.length.should.equal(1);
+			isMemberResults2[0].should.equal(team.teamWithNoExternalTeam.name);
 		});
 	});
 


### PR DESCRIPTION
For some usages on our project, we added an isMember field to the teams search results for scenarios where we'd want to know if the user making the request was a member of some of the teams.

An example use case would be opening up teams listing table to display all teams to users so that they are able to freely request access but disabling links to access teams they are not members of yet.