### PR TITLE
fix: use safer teams object for template rendering

### DIFF
--- a/src/app/core/teams/team.components.yml
+++ b/src/app/core/teams/team.components.yml
@@ -106,12 +106,6 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/NewTeam'
-    RequestAccess:
-      description: Request access to a team
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/NewTeam'
     RequestNewTeam:
       description: Request a new team
       content:

--- a/src/app/core/teams/teams.routes.js
+++ b/src/app/core/teams/teams.routes.js
@@ -112,8 +112,6 @@ router
  *     description: Requests access to a Team. Notifies team admins of the request
  *     parameters:
  *       - $ref: '#/components/parameters/teamIdParam'
- *     requestBody:
- *       $ref: '#/components/requestBodies/RequestAccess'
  *     responses:
  *       '204':
  *         $ref: '#/components/responses/RequestTeamAccess'

--- a/src/app/core/teams/teams.service.js
+++ b/src/app/core/teams/teams.service.js
@@ -571,7 +571,8 @@ const requestAccessToTeam = async (requester, team, req) => {
 	// Add requester role to user for this team
 	await addMemberToTeam(requester, team, 'requester');
 
-	return sendRequestEmail(adminEmails, requester, team, req);
+	// Email template rendering requires simple objects and not Mongo classes
+	return sendRequestEmail(adminEmails, requester, team.toJSON(), req);
 };
 
 const requestNewTeam = async (org, aoi, description, requester, req) => {


### PR DESCRIPTION
This Pull Request aims to fix two things

1. Template has trouble rendering certain Mongo fields like `_id` if they are not simple JSON objects.
2. Swagger documentation is saying that a request body containing a team's object is necessary for the `/team/:teamId/request` route. This is not used because there is `teamId` middleware that pulls the object prior to the controller.


