### PR TITLE
Prevent auditing masquerade user when undefined === undefined

### DIFF
--- a/src/app/core/audit/audit.service.js
+++ b/src/app/core/audit/audit.service.js
@@ -10,7 +10,9 @@ const getMasqueradingUserDn = (eventActor, headers) => {
 	if (config.auth.strategy === 'proxy-pki' && config.auth.masquerade) {
 		const masqueradeUserDn =
 			headers?.[config.masqueradeUserHeader ?? 'x-masquerade-user-dn'];
-
+		if (eventActor.dn === undefined && masqueradeUserDn === undefined) {
+			return undefined;
+		}
 		if (eventActor.dn === masqueradeUserDn) {
 			return headers?.[config.proxyPkiPrimaryUserHeader ?? 'x-ssl-client-s-dn'];
 		}

--- a/src/app/core/audit/audit.service.js
+++ b/src/app/core/audit/audit.service.js
@@ -10,10 +10,7 @@ const getMasqueradingUserDn = (eventActor, headers) => {
 	if (config.auth.strategy === 'proxy-pki' && config.auth.masquerade) {
 		const masqueradeUserDn =
 			headers?.[config.masqueradeUserHeader ?? 'x-masquerade-user-dn'];
-		if (eventActor.dn === undefined && masqueradeUserDn === undefined) {
-			return undefined;
-		}
-		if (eventActor.dn === masqueradeUserDn) {
+		if (eventActor.dn && eventActor.dn === masqueradeUserDn) {
 			return headers?.[config.proxyPkiPrimaryUserHeader ?? 'x-ssl-client-s-dn'];
 		}
 	}


### PR DESCRIPTION
When an audit log doesn't give an eventActor, like for authentication-succeeded, this was causing the masquerade user to be set because both eventActor.dn and the masqueradeUserDn were undefined