### PR TITLE
doc: Expose Swagger UI options via config

### DIFF
--- a/src/lib/express.js
+++ b/src/lib/express.js
@@ -238,10 +238,15 @@ function initSwaggerAPI(app) {
 		);
 	});
 
+	const uiOptions = {
+		filter: true,
+		...config.apiDocs.uiOptions
+	};
+
 	app.use(
 		config.apiDocs.path || '/api-docs',
 		swaggerUi.serve,
-		swaggerUi.setup(swaggerSpec)
+		swaggerUi.setup(swaggerSpec, null, uiOptions)
 	);
 }
 


### PR DESCRIPTION
Swagger UI options can now be set via config.  Filtering is enabled in docs by default.