### PR TITLE
fix(teams): Fix team member text search

### DIFF
--- a/src/app/core/user/user.model.js
+++ b/src/app/core/user/user.model.js
@@ -247,7 +247,9 @@ const UserSchema = new mongoose.Schema({
 UserSchema.plugin(getterPlugin);
 UserSchema.plugin(uniqueValidator);
 UserSchema.plugin(paginatePlugin);
-UserSchema.plugin(containsSearchPlugin);
+UserSchema.plugin(containsSearchPlugin, {
+	fields: ['name', 'username']
+});
 UserSchema.plugin(textSearchPlugin);
 
 /**


### PR DESCRIPTION
Text search for team members was switched to use a contains search, but default fields were not specified.  Sets default fields for user contains search to `name` and `username`.