### PR TITLE
refactor(audit): Streamline audit call by making the http request one…

### DIFF
--- a/src/app/core/audit/audit.service.js
+++ b/src/app/core/audit/audit.service.js
@@ -27,7 +27,7 @@ const getMasqueradingUserDn = (eventActor, headers) => {
  * @param {string} message
  * @param {string} eventType
  * @param {string} eventAction
- * @param {import('express').Request | Promsie<object> | object} requestOrEventActor
+ * @param {import('express').Request | Promise<object> | object} requestOrEventActor
  * @param {object} eventObject
  * @param {*} eventMetadata
  * @returns {Promise<any>}

--- a/src/app/core/audit/audit.service.js
+++ b/src/app/core/audit/audit.service.js
@@ -27,7 +27,7 @@ const getMasqueradingUserDn = (eventActor, headers) => {
  * @param {string} message
  * @param {string} eventType
  * @param {string} eventAction
- * @param {import('express').Request | object} requestOrEventActor
+ * @param {import('express').Request | Promsie<object> | object} requestOrEventActor
  * @param {object} eventObject
  * @param {*} eventMetadata
  * @returns {Promise<any>}
@@ -45,12 +45,14 @@ module.exports.audit = async (
 	 */
 	const Audit = dbs.admin.model('Audit');
 
+	requestOrEventActor = await requestOrEventActor;
+
 	let actor = {};
 	if (requestOrEventActor.name && requestOrEventActor.username) {
 		actor = requestOrEventActor;
 	} else if (requestOrEventActor.user && requestOrEventActor.headers) {
 		const TeamMember = dbs.admin.model('TeamUser');
-		actor = TeamMember.auditCopy(
+		actor = await TeamMember.auditCopy(
 			requestOrEventActor.user,
 			utilService.getHeaderField(requestOrEventActor.headers, 'x-real-ip')
 		);

--- a/src/app/core/audit/audit.service.spec.js
+++ b/src/app/core/audit/audit.service.spec.js
@@ -1,8 +1,7 @@
 'use strict';
 
 const should = require('should'),
-	deps = require('../../../dependencies'),
-	dbs = deps.dbs,
+	{ dbs } = require('../../../dependencies'),
 	Audit = dbs.admin.model('Audit'),
 	auditService = require('./audit.service');
 
@@ -44,7 +43,7 @@ describe('Audit Service:', () => {
 				'some message',
 				'eventType',
 				'eventAction',
-				'eventActor',
+				{ name: 'eventActor', username: 'eventActor' },
 				'eventObject'
 			);
 		});
@@ -55,6 +54,7 @@ describe('Audit Service:', () => {
 				.then((results) => {
 					should(results).be.an.Array();
 					should(results).have.length(1);
+
 					/*
 					 * Audit's created date should be after the unit tests started,
 					 * but may be the same time since ISO Date strips off the milliseconds,
@@ -64,7 +64,10 @@ describe('Audit Service:', () => {
 					should(results[0].message).equal('some message');
 					should(results[0].audit.auditType).equal('eventType');
 					should(results[0].audit.action).equal('eventAction');
-					should(results[0].audit.actor).equal('eventActor');
+					should(results[0].audit.actor).eql({
+						name: 'eventActor',
+						username: 'eventActor'
+					});
 					should(results[0].audit.object).equal('eventObject');
 				});
 		});

--- a/src/app/core/export/export-config.controller.js
+++ b/src/app/core/export/export-config.controller.js
@@ -2,14 +2,8 @@
 
 const os = require('os'),
 	streams = require('stream'),
-	deps = require('../../../dependencies'),
-	dbs = deps.dbs,
-	utilService = deps.utilService,
-	logger = deps.logger,
-	auditService = deps.auditService,
-	csvStream = deps.csvStream,
+	{ dbs, logger, auditService, csvStream } = require('../../../dependencies'),
 	exportConfigService = require('./export-config.service'),
-	TeamMember = dbs.admin.model('TeamUser'),
 	ExportConfig = dbs.admin.model('ExportConfig');
 
 /**
@@ -29,12 +23,8 @@ module.exports.requestExport = async (req, res) => {
 		`${req.body.type} config created`,
 		'export',
 		'create',
-		TeamMember.auditCopy(
-			req.user,
-			utilService.getHeaderField(req.headers, 'x-real-ip')
-		),
-		ExportConfig.auditCopy(generatedConfig),
-		req.headers
+		req,
+		ExportConfig.auditCopy(generatedConfig)
 	);
 
 	res.status(200).json({ _id: generatedConfig._id });

--- a/src/app/core/feedback/feedback.controller.js
+++ b/src/app/core/feedback/feedback.controller.js
@@ -1,15 +1,15 @@
 'use strict';
 
-const deps = require('../../../dependencies'),
-	dbs = deps.dbs,
-	config = deps.config,
-	auditService = deps.auditService,
-	utilService = deps.utilService,
+const {
+		dbs,
+		config,
+		auditService,
+		utilService
+	} = require('../../../dependencies'),
 	exportConfigController = require('../export/export-config.controller'),
 	exportConfigService = require('../export/export-config.service'),
 	feedbackService = require('./feedback.service'),
 	Feedback = dbs.admin.model('Feedback'),
-	TeamMember = dbs.admin.model('TeamUser'),
 	ExportConfig = dbs.admin.model('ExportConfig');
 
 module.exports.submitFeedback = async function (req, res) {
@@ -17,12 +17,8 @@ module.exports.submitFeedback = async function (req, res) {
 		'Feedback submitted',
 		'feedback',
 		'create',
-		TeamMember.auditCopy(
-			req.user,
-			utilService.getHeaderField(req.headers, 'x-real-ip')
-		),
-		req.body,
-		req.headers
+		req,
+		req.body
 	);
 	const feedback = await feedbackService.create(
 		req.user,
@@ -56,12 +52,8 @@ module.exports.adminGetFeedbackCSV = async function (req, res) {
 		`${result.type} CSV config retrieved`,
 		'export',
 		'export',
-		TeamMember.auditCopy(
-			req.user,
-			utilService.getHeaderField(req.headers, 'x-real-ip')
-		),
-		ExportConfig.auditCopy(result),
-		req.headers
+		req,
+		ExportConfig.auditCopy(result)
 	);
 
 	const columns = result.config.cols;
@@ -111,12 +103,8 @@ module.exports.updateFeedbackAssignee = async (req, res) => {
 		'Feedback assignee updated',
 		'feedback',
 		'update',
-		TeamMember.auditCopy(
-			req.user,
-			utilService.getHeaderField(req.headers, 'x-real-ip')
-		),
-		req.body,
-		req.headers
+		req,
+		req.body
 	);
 
 	const updateFeedbackAssigneePromise = feedbackService.updateFeedbackAssignee(
@@ -133,12 +121,8 @@ module.exports.updateFeedbackStatus = async (req, res) => {
 		'Feedback status updated',
 		'feedback',
 		'update',
-		TeamMember.auditCopy(
-			req.user,
-			utilService.getHeaderField(req.headers, 'x-real-ip')
-		),
-		req.body,
-		req.headers
+		req,
+		req.body
 	);
 
 	const updateFeedbackStatusPromise = feedbackService.updateFeedbackStatus(

--- a/src/app/core/messages/message.controller.js
+++ b/src/app/core/messages/message.controller.js
@@ -1,11 +1,7 @@
 'use strict';
 
-const deps = require('../../../dependencies'),
-	dbs = deps.dbs,
-	auditService = deps.auditService,
-	util = deps.utilService,
+const { dbs, auditService } = require('../../../dependencies'),
 	messageService = require('./messages.service'),
-	TeamMember = dbs.admin.model('TeamUser'),
 	Message = dbs.admin.model('Message'),
 	DismissedMessage = dbs.admin.model('DismissedMessage');
 
@@ -21,12 +17,8 @@ module.exports.create = async (req, res) => {
 		'message created',
 		'message',
 		'create',
-		TeamMember.auditCopy(
-			req.user,
-			util.getHeaderField(req.headers, 'x-real-ip')
-		),
-		Message.auditCopy(message),
-		req.headers
+		req,
+		Message.auditCopy(message)
 	);
 
 	res.status(200).json(message);
@@ -45,17 +37,10 @@ module.exports.update = async (req, res) => {
 	const message = messageService.update(req.message, req.body);
 
 	// Audit the save action
-	await auditService.audit(
-		'message updated',
-		'message',
-		'update',
-		TeamMember.auditCopy(
-			req.user,
-			util.getHeaderField(req.headers, 'x-real-ip')
-		),
-		{ before: originalMessage, after: Message.auditCopy(message) },
-		req.headers
-	);
+	await auditService.audit('message updated', 'message', 'update', req, {
+		before: originalMessage,
+		after: Message.auditCopy(message)
+	});
 
 	res.status(200).json(message);
 };
@@ -69,12 +54,8 @@ module.exports.delete = async (req, res) => {
 		'message deleted',
 		'message',
 		'delete',
-		TeamMember.auditCopy(
-			req.user,
-			util.getHeaderField(req.headers, 'x-real-ip')
-		),
-		Message.auditCopy(req.message),
-		req.headers
+		req,
+		Message.auditCopy(req.message)
 	);
 
 	res.status(200).json(req.message);
@@ -133,9 +114,8 @@ exports.dismissMessage = async (req, res) => {
 			'message dismissed',
 			'message',
 			'dismissed',
-			TeamMember.auditCopy(req.user),
-			DismissedMessage.auditCopy(dismissedMessage),
-			req.headers
+			req,
+			DismissedMessage.auditCopy(dismissedMessage)
 		);
 	}
 

--- a/src/app/core/user/auth/user-authentication.controller.js
+++ b/src/app/core/user/auth/user-authentication.controller.js
@@ -1,15 +1,10 @@
 'use strict';
 
-const deps = require('../../../../dependencies'),
-	dbs = deps.dbs,
-	config = deps.config,
-	util = deps.utilService,
-	auditService = deps.auditService,
+const { dbs, config, auditService } = require('../../../../dependencies'),
 	userAuthService = require('./user-authentication.service'),
 	userAuthorizationService = require('./user-authorization.service'),
 	userEmailService = require('../user-email.service'),
 	teamService = require('../../teams/teams.service'),
-	TeamMember = dbs.admin.model('TeamUser'),
 	User = dbs.admin.model('User');
 
 /**
@@ -27,12 +22,8 @@ async function adminCreateUser(user, req, res) {
 		'admin user create',
 		'user',
 		'admin user create',
-		TeamMember.auditCopy(
-			req.user,
-			util.getHeaderField(req.headers, 'x-real-ip')
-		),
-		User.auditCopy(result),
-		req.headers
+		req,
+		User.auditCopy(result)
 	);
 	res.status(200).json(User.fullCopy(result));
 }
@@ -50,9 +41,8 @@ const signup = async (user, req, res) => {
 		'user signup',
 		'user',
 		'user signup',
-		{},
-		User.auditCopy(newUser),
-		req.headers
+		req,
+		User.auditCopy(newUser)
 	);
 
 	const result = await userAuthService.login(user, req);

--- a/src/app/core/user/auth/user-authentication.service.js
+++ b/src/app/core/user/auth/user-authentication.service.js
@@ -2,13 +2,8 @@
 
 const _ = require('lodash'),
 	passport = require('passport'),
-	deps = require('../../../../dependencies'),
-	auditService = deps.auditService,
-	config = deps.config,
-	dbs = deps.dbs,
-	util = deps.utilService,
+	{ auditService, config, dbs } = require('../../../../dependencies'),
 	User = dbs.admin.model('User'),
-	TeamMember = dbs.admin.model('TeamUser'),
 	accessChecker = require('../../access-checker/access-checker.service'),
 	userEmailService = require('../../user/user-email.service');
 
@@ -78,9 +73,8 @@ module.exports.login = (user, req) => {
 				'User successfully logged in',
 				'user-authentication',
 				'authentication succeeded',
-				{},
-				User.auditCopy(user, util.getHeaderField(req.headers, 'x-real-ip')),
-				req.headers
+				req,
+				{}
 			);
 		});
 	});
@@ -122,9 +116,8 @@ module.exports.authenticateAndLogin = function (req, res, next) {
 					info.message,
 					'user-authentication',
 					'authentication failed',
-					{},
-					{ username: username },
-					req.headers
+					req,
+					{ username: username }
 				);
 
 				return reject(info);
@@ -203,7 +196,7 @@ const autoCreateUser = async (dn, req, acUser) => {
 		'user signup',
 		'user',
 		'user signup',
-		{},
+		req,
 		User.auditCopy(newUser)
 	);
 
@@ -249,7 +242,7 @@ module.exports.verifyUser = async (dn, req, isProxy = false) => {
 		'user updated from access checker',
 		'user',
 		'update',
-		TeamMember.auditCopy(localUser),
+		req,
 		User.auditCopy(localUser)
 	);
 

--- a/src/app/core/user/eua/eua.controller.js
+++ b/src/app/core/user/eua/eua.controller.js
@@ -1,11 +1,7 @@
 'use strict';
 
-const deps = require('../../../../dependencies'),
-	dbs = deps.dbs,
-	util = deps.utilService,
-	auditService = deps.auditService,
+const { dbs, auditService } = require('../../../../dependencies'),
 	euaService = require('./eua.service'),
-	TeamMember = dbs.admin.model('TeamUser'),
 	User = dbs.admin.model('User'),
 	UserAgreement = dbs.admin.model('UserAgreement');
 
@@ -31,12 +27,8 @@ module.exports.publishEua = async (req, res) => {
 		'eua published',
 		'eua',
 		'published',
-		TeamMember.auditCopy(
-			req.user,
-			util.getHeaderField(req.headers, 'x-real-ip')
-		),
-		UserAgreement.auditCopy(result),
-		req.headers
+		req,
+		UserAgreement.auditCopy(result)
 	);
 
 	res.status(200).json(result);
@@ -47,17 +39,7 @@ module.exports.acceptEua = async (req, res) => {
 	const user = await euaService.acceptEua(req.user);
 
 	// Audit accepted eua
-	await auditService.audit(
-		'eua accepted',
-		'eua',
-		'accepted',
-		TeamMember.auditCopy(
-			req.user,
-			util.getHeaderField(req.headers, 'x-real-ip')
-		),
-		{},
-		req.headers
-	);
+	await auditService.audit('eua accepted', 'eua', 'accepted', req, {});
 
 	res.status(200).json(User.fullCopy(user));
 };
@@ -71,12 +53,8 @@ module.exports.createEua = async (req, res) => {
 		'eua create',
 		'eua',
 		'create',
-		TeamMember.auditCopy(
-			req.user,
-			util.getHeaderField(req.headers, 'x-real-ip')
-		),
-		UserAgreement.auditCopy(result),
-		req.headers
+		req,
+		UserAgreement.auditCopy(result)
 	);
 
 	res.status(200).json(result);
@@ -101,20 +79,10 @@ module.exports.updateEua = async (req, res) => {
 	const results = await euaService.update(req.euaParam, req.body);
 
 	// Audit user update
-	await auditService.audit(
-		'end user agreement updated',
-		'eua',
-		'update',
-		TeamMember.auditCopy(
-			req.user,
-			util.getHeaderField(req.headers, 'x-real-ip')
-		),
-		{
-			before: originalEua,
-			after: UserAgreement.auditCopy(results)
-		},
-		req.headers
-	);
+	await auditService.audit('end user agreement updated', 'eua', 'update', req, {
+		before: originalEua,
+		after: UserAgreement.auditCopy(results)
+	});
 
 	res.status(200).json(results);
 };
@@ -131,12 +99,8 @@ module.exports.deleteEua = async (req, res) => {
 		'eua deleted',
 		'eua',
 		'delete',
-		TeamMember.auditCopy(
-			req.user,
-			util.getHeaderField(req.headers, 'x-real-ip')
-		),
-		UserAgreement.auditCopy(eua),
-		req.headers
+		req,
+		UserAgreement.auditCopy(eua)
 	);
 
 	res.status(200).json(results);

--- a/src/app/core/user/profile/user-profile.controller.js
+++ b/src/app/core/user/profile/user-profile.controller.js
@@ -1,12 +1,12 @@
 'use strict';
 
 const _ = require('lodash'),
-	deps = require('../../../../dependencies'),
-	config = deps.config,
-	dbs = deps.dbs,
-	util = deps.utilService,
-	auditService = deps.auditService,
-	TeamMember = dbs.admin.model('TeamUser'),
+	{
+		config,
+		dbs,
+		utilService,
+		auditService
+	} = require('../../../../dependencies'),
 	User = dbs.admin.model('User'),
 	userAuthorizationService = require('../auth/user-authorization.service'),
 	userService = require('../user.service'),
@@ -73,12 +73,8 @@ exports.updateCurrentUser = async (req, res) => {
 				'user update authentication failed',
 				'user',
 				'update authentication failed',
-				TeamMember.auditCopy(
-					req.user,
-					util.getHeaderField(req.headers, 'x-real-ip')
-				),
-				{},
-				req.headers
+				req,
+				{}
 			);
 
 			res.status(400).json({
@@ -100,20 +96,10 @@ exports.updateCurrentUser = async (req, res) => {
 		delete user.salt;
 
 		// Audit user update
-		auditService.audit(
-			'user updated',
-			'user',
-			'update',
-			TeamMember.auditCopy(
-				req.user,
-				util.getHeaderField(req.headers, 'x-real-ip')
-			),
-			{
-				before: originalUser,
-				after: User.auditCopy(user)
-			},
-			req.headers
-		);
+		auditService.audit('user updated', 'user', 'update', req, {
+			before: originalUser,
+			after: User.auditCopy(user)
+		});
 
 		// Log in with the new info
 		req.login(user, (error) => {
@@ -123,7 +109,7 @@ exports.updateCurrentUser = async (req, res) => {
 			res.status(200).json(User.fullCopy(user));
 		});
 	} catch (err) {
-		util.catchError(res, err);
+		utilService.catchError(res, err);
 	}
 };
 

--- a/src/app/core/user/user-export.controller.js
+++ b/src/app/core/user/user-export.controller.js
@@ -1,10 +1,7 @@
 'use strict';
 
 const _ = require('lodash'),
-	deps = require('../../../dependencies'),
-	config = deps.config,
-	dbs = deps.dbs,
-	auditService = deps.auditService,
+	{ config, dbs, auditService } = require('../../../dependencies'),
 	Team = dbs.admin.model('Team'),
 	TeamMember = dbs.admin.model('TeamUser'),
 	ExportConfig = dbs.admin.model('ExportConfig'),
@@ -29,9 +26,8 @@ module.exports.adminGetCSV = async (req, res) => {
 		`${result.type} CSV config retrieved`,
 		'export',
 		'export',
-		TeamMember.auditCopy(req.user),
-		ExportConfig.auditCopy(result),
-		req.headers
+		req,
+		ExportConfig.auditCopy(result)
 	);
 
 	const columns = result.config.cols,

--- a/src/dependencies.js
+++ b/src/dependencies.js
@@ -15,13 +15,13 @@ module.exports.dbs = require('./lib/mongoose').dbs;
 // Socket IO
 module.exports.socketIO = require('./lib/socket.io');
 
-// Core Services
-module.exports.auditService = require('./app/core/audit/audit.service');
-module.exports.emailService = require('./app/core/email/email.service');
-
 // Common Services
 module.exports.errorService = require('./app/common/errors.service');
 module.exports.utilService = require('./app/common/util.service');
 module.exports.schemaService = require('./app/common/schema.service');
 module.exports.csvStream = require('./app/common/csv-stream.service');
 module.exports.delayedStream = require('./app/common/delayed-stream.service');
+
+// Core Services
+module.exports.auditService = require('./app/core/audit/audit.service');
+module.exports.emailService = require('./app/core/email/email.service');


### PR DESCRIPTION
… of its arguments.

Previously, everytime we called `auditService.audit(...)` we would repeat the following steps:
* Create audit copy of current user
* Extract user IP from http headers and add to audit copy of user
* pass in http headers as event metadata when making audit call

This removes the duplicated logic mentioned it above and moves it into the audit call.  Audit call now optionally (for compatibility) accepts the http request as a parameter in place of the event actor.