### PR TITLE
deps: removed body-parser.

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "JSONPath": "0.11",
     "agenda": "^4.3.0",
     "async": "2.6",
-    "body-parser": "1.18",
     "bunyan": "1.8",
     "chalk": "2",
     "colors": "1",

--- a/src/app/core/feedback/feedback.controller.spec.js
+++ b/src/app/core/feedback/feedback.controller.spec.js
@@ -6,7 +6,6 @@ require('express-async-errors');
 
 const request = require('supertest'),
 	should = require('should'),
-	bodyParser = require('body-parser'),
 	mock = require('mock-require'),
 	deps = require('../../../dependencies'),
 	Feedback = deps.dbs.admin.model('Feedback'),
@@ -27,7 +26,7 @@ describe('Feedback Controller', () => {
 
 	before(() => {
 		app = express();
-		app.use(bodyParser.json());
+		app.use(express.json());
 
 		// Mock access for the User Controller method that adds authentication to these endpoints
 		mock('../user/user.controller', {

--- a/src/app/core/user/eua/eua.routes.spec.js
+++ b/src/app/core/user/eua/eua.routes.spec.js
@@ -4,8 +4,7 @@ const express = require('express');
 // Patches express to support async/await.  Should be called immediately after express.
 require('express-async-errors');
 
-const bodyParser = require('body-parser'),
-	mock = require('mock-require'),
+const mock = require('mock-require'),
 	request = require('supertest'),
 	should = require('should'),
 	{
@@ -45,7 +44,7 @@ describe('EUA Routes:', () => {
 
 	before(() => {
 		app = express();
-		app.use(bodyParser.json());
+		app.use(express.json());
 
 		userCtrl = mock.reRequire('../user.controller');
 

--- a/src/lib/express.js
+++ b/src/lib/express.js
@@ -8,7 +8,6 @@ const _ = require('lodash'),
 	path = require('path'),
 	config = require('../config'),
 	logger = require('./bunyan').logger,
-	bodyParser = require('body-parser'),
 	compress = require('compression'),
 	cookieParser = require('cookie-parser'),
 	session = require('express-session'),
@@ -82,11 +81,11 @@ function initMiddleware(app) {
 
 	// Request body parsing middleware should be above methodOverride
 	app.use(
-		bodyParser.urlencoded({
+		express.urlencoded({
 			extended: true
 		})
 	);
-	app.use(bodyParser.json());
+	app.use(express.json());
 	app.use(methodOverride());
 
 	// Add the cookie parser and flash middleware


### PR DESCRIPTION
Removed the body-parser dep and replaced calls to `app.user(bodyParser())` with `app.use(express.json())`

Closes #152 

With body-parser removed, downstream projects will definitely need to take care to update their custom stuff.