### PR TITLE
Cleaning up lint issues with typescript files

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "link:prod": "ln -s ../config ./dist/config && ln -s ../node_modules ./dist/node_modules && ln -s ../package.json ./dist/package.json && ln -s ../package-lock.json ./dist/package-lock.json",
     "lint": "npm run lint:eslint",
     "lint:fix": "npm run lint:eslint:fix",
-    "lint:eslint": "eslint \"./**/*.js\" \"./**/*.ts\"",
-    "lint:eslint:fix": "eslint \"./**/*.js\" \"./**/*.ts\" --fix",
+    "lint:eslint": "eslint \"./**/*.{js, ts}\"",
+    "lint:eslint:fix": "eslint \"./**/*.{js, ts}\" --fix",
     "tsc:check": "tsc --project tsconfig.json --noEmit",
     "tsc:watch": "tsc --watch --noEmit",
     "prepare": "husky install"
@@ -114,6 +114,6 @@
     "supertest": "3.3"
   },
   "lint-staged": {
-    "*.js": "eslint --fix"
+    "*.{js, ts}": "eslint --fix"
   }
 }

--- a/src/app/core/audit/types.d.ts
+++ b/src/app/core/audit/types.d.ts
@@ -16,6 +16,6 @@ interface IAudit extends Document {
 	};
 }
 
-export interface AuditDocument extends IAudit {}
+export type AuditDocument = IAudit;
 
-export interface AuditModel extends Model<AuditDocument> {}
+export type AuditModel = Model<AuditDocument>;

--- a/src/app/core/audit/types.d.ts
+++ b/src/app/core/audit/types.d.ts
@@ -6,8 +6,8 @@ interface IAudit extends Document {
 	audit: {
 		auditType: string;
 		action: string;
-		actor: Object;
-		object: string | Object;
+		actor: Record<string, unknown>;
+		object: string | Record<string, unknown>;
 		userSpec: {
 			browser: string;
 			os: string;

--- a/src/app/core/feedback/types.d.ts
+++ b/src/app/core/feedback/types.d.ts
@@ -23,7 +23,7 @@ interface IFeedback extends Document {
 	updated: Date | number;
 }
 
-export interface FeedbackDocument extends IFeedback {}
+export type FeedbackDocument = IFeedback;
 
 type QueryHelpers<T> = TextSearchPlugin & PaginatePlugin<T>;
 

--- a/src/app/core/messages/types.d.ts
+++ b/src/app/core/messages/types.d.ts
@@ -11,7 +11,7 @@ interface IMessage extends Document {
 	updated: Date | number;
 }
 
-export interface MessageDocument extends IMessage {}
+export type MessageDocument = IMessage;
 
 export type LeanMessageDocument = LeanDocument<MessageDocument>;
 
@@ -29,7 +29,7 @@ interface IDismissedMessage extends Document {
 	created: number;
 }
 
-export interface DismissedMessageDocument extends IDismissedMessage {}
+export type DismissedMessageDocument = IDismissedMessage;
 
 export type LeanDismissedMessageDocument = LeanDocument<DismissedMessageDocument>;
 

--- a/src/app/core/resources/types.d.ts
+++ b/src/app/core/resources/types.d.ts
@@ -1,13 +1,4 @@
-import {
-	Document,
-	Model,
-	model,
-	Types,
-	Schema,
-	Query,
-	Mongoose
-} from 'mongoose';
-import { BinaryLike } from 'crypto';
+import { Document, Model } from 'mongoose';
 
 interface IResource extends Document {
 	_id: string;

--- a/src/app/core/resources/types.d.ts
+++ b/src/app/core/resources/types.d.ts
@@ -19,6 +19,6 @@ interface IResource extends Document {
 	tags: string[];
 }
 
-export interface ResourceDocument extends IResource {}
+export type ResourceDocument = IResource;
 
-export interface ResourceModel extends Model<ResourceDocument> {}
+export type ResourceModel = Model<ResourceDocument>;

--- a/src/app/core/teams/types.d.ts
+++ b/src/app/core/teams/types.d.ts
@@ -18,7 +18,7 @@ interface ITeam extends Document {
 	ancestors: MongooseTypes.ObjectId[];
 }
 
-export interface TeamDocument extends ITeam {}
+export type TeamDocument = ITeam;
 
 type QueryHelpers<T> = ContainsSearchPlugin & PaginatePlugin<T>;
 

--- a/src/app/core/teams/types.d.ts
+++ b/src/app/core/teams/types.d.ts
@@ -1,8 +1,5 @@
 import { Document, Model, Types as MongooseTypes } from 'mongoose';
-import {
-	ContainsSearchPlugin,
-	TextSearchPlugin
-} from '../../common/mongoose/types';
+import { ContainsSearchPlugin } from '../../common/mongoose/types';
 
 interface ITeam extends Document {
 	name: string;
@@ -24,5 +21,5 @@ type QueryHelpers<T> = ContainsSearchPlugin & PaginatePlugin<T>;
 
 export interface TeamModel
 	extends Model<TeamDocument, QueryHelpers<TeamDocument>> {
-	auditCopy(team: Object): Object;
+	auditCopy(team: Record<string, unknown>): Record<string, unknown>;
 }

--- a/src/app/core/user/eua/types.d.ts
+++ b/src/app/core/user/eua/types.d.ts
@@ -9,7 +9,7 @@ interface IUserAgreement extends Document {
 	created: Date | number;
 }
 
-export interface UserAgreementDocument extends IUserAgreement {}
+export type UserAgreementDocument = IUserAgreement;
 
 type QueryHelpers<T> = TextSearchPlugin & PaginatePlugin<T> & PagedStreamPlugin;
 

--- a/src/app/core/user/eua/types.d.ts
+++ b/src/app/core/user/eua/types.d.ts
@@ -15,5 +15,5 @@ type QueryHelpers<T> = TextSearchPlugin & PaginatePlugin<T> & PagedStreamPlugin;
 
 export interface UserAgreementModel
 	extends Model<UserAgreementDocument, QueryHelpers<UserAgreementDocument>> {
-	auditCopy(eua: Object): Object;
+	auditCopy(eua: Record<string, unknown>): Record<string, unknown>;
 }

--- a/src/app/core/user/types.d.ts
+++ b/src/app/core/user/types.d.ts
@@ -16,14 +16,14 @@ interface IUser extends Document {
 	name: string;
 
 	organization: string;
-	organizationLevels: Object;
+	organizationLevels: Record<string, unknown>;
 	email: string;
 	phone: string;
 	username: string;
 	password: string;
 	provider: string;
-	providerData: Object;
-	additionalProvidersData: Object;
+	providerData: Record<string, unknown>;
+	additionalProvidersData: Record<string, unknown>;
 	roles: UserRoles;
 	canProxy: boolean;
 	externalGroups: string[];
@@ -39,7 +39,7 @@ interface IUser extends Document {
 	lastLogin: Date | number;
 	lastLoginWithAccess: Date | number;
 	newFeatureDismissed: Date;
-	preferences: Object;
+	preferences: Record<string, unknown>;
 	salt: BinaryLike;
 }
 
@@ -54,6 +54,9 @@ type QueryHelpers<T> = ContainsSearchPlugin &
 
 export interface UserModel
 	extends Model<UserDocument, QueryHelpers<UserDocument>> {
-	createCopy(user: Object): Object;
-	auditCopy(user: Object, userIP?: string): Object;
+	createCopy(user: Record<string, unknown>): Record<string, unknown>;
+	auditCopy(
+		user: Record<string, unknown>,
+		userIP?: string
+	): Record<string, unknown>;
 }

--- a/src/clusterserver.ts
+++ b/src/clusterserver.ts
@@ -1,9 +1,9 @@
 'use strict';
 
-const config = require('./config'),
-	startupPromise = require('./startup')(),
-	sticky = require('socketio-sticky-session'),
-	logger = require('./lib/bunyan').logger;
+import config from './config';
+import startupFn from './startup';
+import sticky from 'socketio-sticky-session';
+import { logger } from './lib/bunyan';
 
 const defaultOptions = {
 	proxy: true, //activate layer 4 patching
@@ -15,7 +15,7 @@ const defaultOptions = {
 const options = config.clusterConfig || defaultOptions;
 logger.info(`Cluster confg: ${JSON.stringify(options)}`);
 
-startupPromise
+startupFn()
 	.then((app) => {
 		sticky(options, () => app).listen(config.port, () => {
 			logger.info(`server started on ${config.port} port`);


### PR DESCRIPTION
1. Ran `npm run lint:fix` that automatically fixed these issues.
2. Updated clusterserver.js to use new typescript construct, including the startup function