### PR TITLE
refactor: convert teams module to typescript

### DIFF
--- a/src/app/core/teams/teams.controller.spec.ts
+++ b/src/app/core/teams/teams.controller.spec.ts
@@ -1,14 +1,17 @@
-'use strict';
+import { Request } from 'express';
+import should from 'should';
+import { assert, createSandbox, match, spy, stub } from 'sinon';
 
-const should = require('should'),
-	sinon = require('sinon'),
-	teamsController = require('./teams.controller'),
-	teamsService = require('./teams.service'),
-	userService = require('../user/user.service'),
-	{ auditService, dbs, logger } = require('../../../dependencies');
+import { auditService, dbs, logger } from '../../../dependencies';
+import { UserDocument } from '../user/types';
+import { UserModel } from '../user/user.model';
+import userService from '../user/user.service';
+import { TeamDocument, TeamModel } from './team.model';
+import * as teamsController from './teams.controller';
+import teamsService from './teams.service';
 
-const Team = dbs.admin.model('Team');
-const User = dbs.admin.model('User');
+const Team: TeamModel = dbs.admin.model('Team');
+const User: UserModel = dbs.admin.model('User');
 
 /**
  * Unit tests
@@ -18,11 +21,11 @@ describe('Teams Controller:', () => {
 	let sandbox;
 
 	beforeEach(() => {
-		sandbox = sinon.createSandbox();
+		sandbox = createSandbox();
 		res = {
-			json: sinon.spy(),
-			end: sinon.spy(),
-			status: sinon.stub()
+			json: spy(),
+			end: spy(),
+			status: stub()
 		};
 		res.status.returns(res);
 	});
@@ -42,11 +45,11 @@ describe('Teams Controller:', () => {
 
 			await teamsController.create(req, res);
 
-			sinon.assert.calledOnce(teamsService.create);
-			sinon.assert.calledOnce(auditService.audit);
+			assert.calledOnce(teamsService.create);
+			assert.calledOnce(auditService.audit);
 
-			sinon.assert.calledWith(res.status, 200);
-			sinon.assert.called(res.json);
+			assert.calledWith(res.status, 200);
+			assert.called(res.json);
 		});
 	});
 
@@ -59,8 +62,8 @@ describe('Teams Controller:', () => {
 
 			await teamsController.read(req, res);
 
-			sinon.assert.calledWith(res.status, 200);
-			sinon.assert.called(res.json);
+			assert.calledWith(res.status, 200);
+			assert.called(res.json);
 		});
 	});
 
@@ -76,11 +79,11 @@ describe('Teams Controller:', () => {
 
 			await teamsController.update(req, res);
 
-			sinon.assert.calledOnce(auditService.audit);
-			sinon.assert.calledOnce(teamsService.update);
+			assert.calledOnce(auditService.audit);
+			assert.calledOnce(teamsService.update);
 
-			sinon.assert.calledWith(res.status, 200);
-			sinon.assert.called(res.json);
+			assert.calledWith(res.status, 200);
+			assert.called(res.json);
 		});
 	});
 
@@ -95,13 +98,13 @@ describe('Teams Controller:', () => {
 			sandbox.stub(auditService, 'audit').resolves();
 			sandbox.stub(teamsService, 'delete').resolves();
 
-			await teamsController.delete(req, res);
+			await teamsController.deleteTeam(req, res);
 
-			sinon.assert.calledOnce(auditService.audit);
-			sinon.assert.calledOnce(teamsService.delete);
+			assert.calledOnce(auditService.audit);
+			assert.calledOnce(teamsService.delete);
 
-			sinon.assert.calledWith(res.status, 200);
-			sinon.assert.called(res.json);
+			assert.calledWith(res.status, 200);
+			assert.called(res.json);
 		});
 	});
 
@@ -115,10 +118,10 @@ describe('Teams Controller:', () => {
 
 			await teamsController.search(req, res);
 
-			sinon.assert.calledOnce(teamsService.search);
+			assert.calledOnce(teamsService.search);
 
-			sinon.assert.calledWith(res.status, 200);
-			sinon.assert.called(res.json);
+			assert.calledWith(res.status, 200);
+			assert.called(res.json);
 		});
 	});
 
@@ -136,12 +139,12 @@ describe('Teams Controller:', () => {
 
 			await teamsController.requestNewTeam(req, res);
 
-			sinon.assert.calledOnce(teamsService.requestNewTeam);
-			sinon.assert.calledOnce(auditService.audit);
+			assert.calledOnce(teamsService.requestNewTeam);
+			assert.calledOnce(auditService.audit);
 
-			sinon.assert.calledWith(res.status, 204);
-			sinon.assert.called(res.end);
-			sinon.assert.notCalled(res.json);
+			assert.calledWith(res.status, 204);
+			assert.called(res.end);
+			assert.notCalled(res.json);
 		});
 	});
 
@@ -158,11 +161,11 @@ describe('Teams Controller:', () => {
 
 			await teamsController.requestAccess(req, res);
 
-			sinon.assert.calledOnce(teamsService.requestAccessToTeam);
+			assert.calledOnce(teamsService.requestAccessToTeam);
 
-			sinon.assert.calledWith(res.status, 204);
-			sinon.assert.called(res.end);
-			sinon.assert.notCalled(res.json);
+			assert.calledWith(res.status, 204);
+			assert.called(res.end);
+			assert.notCalled(res.json);
 		});
 	});
 
@@ -177,10 +180,10 @@ describe('Teams Controller:', () => {
 
 			await teamsController.searchMembers(req, res);
 
-			sinon.assert.calledOnce(userService.searchUsers);
+			assert.calledOnce(userService.searchUsers);
 
-			sinon.assert.calledWith(res.status, 200);
-			sinon.assert.called(res.json);
+			assert.calledWith(res.status, 200);
+			assert.called(res.json);
 		});
 	});
 
@@ -199,12 +202,12 @@ describe('Teams Controller:', () => {
 
 			await teamsController.addMember(req, res);
 
-			sinon.assert.calledOnce(auditService.audit);
-			sinon.assert.calledOnce(teamsService.addMemberToTeam);
+			assert.calledOnce(auditService.audit);
+			assert.calledOnce(teamsService.addMemberToTeam);
 
-			sinon.assert.calledWith(res.status, 204);
-			sinon.assert.called(res.end);
-			sinon.assert.notCalled(res.json);
+			assert.calledWith(res.status, 204);
+			assert.called(res.end);
+			assert.notCalled(res.json);
 		});
 	});
 
@@ -236,12 +239,12 @@ describe('Teams Controller:', () => {
 
 			await teamsController.addMembers(req, res);
 
-			sinon.assert.calledOnce(auditService.audit);
-			sinon.assert.calledOnce(teamsService.addMemberToTeam);
+			assert.calledOnce(auditService.audit);
+			assert.calledOnce(teamsService.addMemberToTeam);
 
-			sinon.assert.calledWith(res.status, 204);
-			sinon.assert.called(res.end);
-			sinon.assert.notCalled(res.json);
+			assert.calledWith(res.status, 204);
+			assert.called(res.end);
+			assert.notCalled(res.json);
 		});
 	});
 
@@ -260,12 +263,12 @@ describe('Teams Controller:', () => {
 
 			await teamsController.removeMember(req, res);
 
-			sinon.assert.calledOnce(auditService.audit);
-			sinon.assert.calledOnce(teamsService.removeMemberFromTeam);
+			assert.calledOnce(auditService.audit);
+			assert.calledOnce(teamsService.removeMemberFromTeam);
 
-			sinon.assert.calledWith(res.status, 204);
-			sinon.assert.called(res.end);
-			sinon.assert.notCalled(res.json);
+			assert.calledWith(res.status, 204);
+			assert.called(res.end);
+			assert.notCalled(res.json);
 		});
 	});
 
@@ -284,12 +287,12 @@ describe('Teams Controller:', () => {
 
 			await teamsController.updateMemberRole(req, res);
 
-			sinon.assert.calledOnce(auditService.audit);
-			sinon.assert.calledOnce(teamsService.updateMemberRole);
+			assert.calledOnce(auditService.audit);
+			assert.calledOnce(teamsService.updateMemberRole);
 
-			sinon.assert.calledWith(res.status, 204);
-			sinon.assert.called(res.end);
-			sinon.assert.notCalled(res.json);
+			assert.calledWith(res.status, 204);
+			assert.called(res.end);
+			assert.notCalled(res.json);
 		});
 	});
 
@@ -304,29 +307,27 @@ describe('Teams Controller:', () => {
 				}
 			});
 
-			const nextFn = sinon.stub();
-			const req = { user: {}, body: {} };
+			const nextFn = stub();
+			const req = { user: {}, body: {} } as Request & { team: TeamDocument };
 
 			await teamsController.teamById(req, {}, nextFn, 'id');
 
 			should.exist(req.team);
-			sinon.assert.calledWith(nextFn);
+			assert.calledWith(nextFn);
 		});
 
 		it('team not found', async () => {
 			sandbox.stub(teamsService, 'read').resolves();
 
-			const nextFn = sinon.stub();
-			const req = { user: {} };
+			const nextFn = stub();
+			const req = { user: {} } as Request & { team: TeamDocument };
 
 			await teamsController.teamById(req, {}, nextFn, 'id');
 
 			should.not.exist(req.team);
-			sinon.assert.calledWith(
+			assert.calledWith(
 				nextFn,
-				sinon.match
-					.instanceOf(Error)
-					.and(sinon.match.has('message', 'Could not find team'))
+				match.instanceOf(Error).and(match.has('message', 'Could not find team'))
 			);
 		});
 	});
@@ -342,47 +343,49 @@ describe('Teams Controller:', () => {
 				}
 			});
 
-			const nextFn = sinon.stub();
-			const req = { user: {}, body: {} };
+			const nextFn = stub();
+			const req = { user: {}, body: {} } as Request & {
+				userParam: UserDocument;
+			};
 
 			await teamsController.teamMemberById(req, {}, nextFn, 'id');
 
 			should.exist(req.userParam);
-			sinon.assert.calledWith(nextFn);
+			assert.calledWith(nextFn);
 		});
 
 		it('team not found', async () => {
 			sandbox.stub(userService, 'read').resolves();
 
-			const nextFn = sinon.stub();
-			const req = { user: {} };
+			const nextFn = stub();
+			const req = { user: {} } as Request & { userParam: UserDocument };
 
 			await teamsController.teamMemberById(req, {}, nextFn, 'id');
 
 			should.not.exist(req.userParam);
-			sinon.assert.calledWith(
+			assert.calledWith(
 				nextFn,
-				sinon.match
+				match
 					.instanceOf(Error)
-					.and(sinon.match.has('message', 'Failed to load team member'))
+					.and(match.has('message', 'Failed to load team member'))
 			);
 		});
 	});
 
 	describe('requiresRole', () => {
-		['requiresAdmin', 'requiresEditor', 'requiresMember'].forEach((method) => {
+		const requiresRoleHelper = (method, testFunction) => {
 			describe(method, () => {
 				it('user not found', async () => {
 					sandbox.stub(teamsService, 'meetsRoleRequirement').resolves();
 
 					const req = {};
 
-					await teamsController[method](req).should.be.rejectedWith({
+					await testFunction(req).should.be.rejectedWith({
 						status: 400,
 						message: 'No user for request'
 					});
 
-					sinon.assert.notCalled(teamsService.meetsRoleRequirement);
+					assert.notCalled(teamsService.meetsRoleRequirement);
 				});
 
 				it('team not found', async () => {
@@ -390,12 +393,12 @@ describe('Teams Controller:', () => {
 
 					const req = { user: {} };
 
-					await teamsController[method](req).should.be.rejectedWith({
+					await testFunction(req).should.be.rejectedWith({
 						status: 400,
 						message: 'No team for request'
 					});
 
-					sinon.assert.notCalled(teamsService.meetsRoleRequirement);
+					assert.notCalled(teamsService.meetsRoleRequirement);
 				});
 
 				it('team not found', async () => {
@@ -403,11 +406,17 @@ describe('Teams Controller:', () => {
 
 					const req = { user: {}, team: {} };
 
-					await teamsController[method](req).should.be.fulfilled();
+					await testFunction(req).should.be.fulfilled();
 
-					sinon.assert.calledOnce(teamsService.meetsRoleRequirement);
+					assert.calledOnce(teamsService.meetsRoleRequirement);
 				});
 			});
-		});
+		};
+
+		requiresRoleHelper('requiresAdmin', teamsController.requiresAdmin);
+
+		requiresRoleHelper('requiresEditor', teamsController.requiresEditor);
+
+		requiresRoleHelper('requiresMember', teamsController.requiresMember);
 	});
 });

--- a/src/app/core/teams/teams.controller.ts
+++ b/src/app/core/teams/teams.controller.ts
@@ -1,16 +1,15 @@
-'use strict';
+import { dbs, utilService, auditService } from '../../../dependencies';
+import UserService from '../user/user.service';
+import { TeamRoles } from './team-role.model';
+import TeamsService from './teams.service';
 
-const { dbs, utilService, auditService } = require('../../../dependencies'),
-	teamsService = require('./teams.service'),
-	userService = require('../user/user.service');
-
-const User = dbs.admin.model('User');
+const UserModel = dbs.admin.model('User');
 
 /**
  * Create a new team. The team creator is automatically added as an admin
  */
-module.exports.create = async (req, res) => {
-	const result = await teamsService.create(
+export const create = async (req, res) => {
+	const result = await TeamsService.create(
 		req.body.team,
 		req.user,
 		req.body.firstAdmin
@@ -31,18 +30,18 @@ module.exports.create = async (req, res) => {
 /**
  * Read the team
  */
-module.exports.read = (req, res) => {
+export const read = (req, res) => {
 	res.status(200).json(req.team);
 };
 
 /**
  * Update the team metadata
  */
-module.exports.update = async (req, res) => {
+export const update = async (req, res) => {
 	// Make a copy of the original team for auditing purposes
 	const originalTeam = req.team.auditCopy();
 
-	const result = await teamsService.update(req.team, req.body);
+	const result = await TeamsService.update(req.team, req.body);
 
 	await auditService.audit('team updated', 'team', 'update', req, {
 		before: originalTeam,
@@ -55,8 +54,8 @@ module.exports.update = async (req, res) => {
 /**
  * Delete the team
  */
-module.exports.delete = async (req, res) => {
-	await teamsService.delete(req.team);
+export const deleteTeam = async (req, res) => {
+	await TeamsService.delete(req.team);
 
 	// Audit the team delete attempt
 	await auditService.audit(
@@ -73,27 +72,27 @@ module.exports.delete = async (req, res) => {
 /**
  * Search the teams, includes paging and sorting
  */
-module.exports.search = async (req, res) => {
+export const search = async (req, res) => {
 	// Get search and query parameters
 	const search = req.body.s ?? null;
 	const query = utilService.toMongoose(req.body.q ?? {});
 
-	const result = await teamsService.search(req.query, query, search, req.user);
+	const result = await TeamsService.search(req.query, query, search, req.user);
 	res.status(200).json(result);
 };
 
-module.exports.getAncestorTeamIds = async (req, res) => {
-	const result = await teamsService.getAncestorTeamIds(req.body.teamIds);
+export const getAncestorTeamIds = async (req, res) => {
+	const result = await TeamsService.getAncestorTeamIds(req.body.teamIds);
 	res.status(200).json(result);
 };
 
-module.exports.requestNewTeam = async (req, res) => {
+export const requestNewTeam = async (req, res) => {
 	const user = req.user;
 	const org = req.body.org ?? null;
 	const aoi = req.body.aoi ?? null;
 	const description = req.body.description ?? null;
 
-	await teamsService.requestNewTeam(org, aoi, description, user, req);
+	await TeamsService.requestNewTeam(org, aoi, description, user, req);
 
 	await auditService.audit('new team requested', 'team', 'request', req, {
 		org,
@@ -104,23 +103,23 @@ module.exports.requestNewTeam = async (req, res) => {
 	res.status(204).end();
 };
 
-module.exports.requestAccess = async (req, res) => {
-	await teamsService.requestAccessToTeam(req.user, req.team, req);
+export const requestAccess = async (req, res) => {
+	await TeamsService.requestAccessToTeam(req.user, req.team, req);
 	res.status(204).end();
 };
 
 /**
  * Search the members of the team, includes paging and sorting
  */
-module.exports.searchMembers = async (req, res) => {
+export const searchMembers = async (req, res) => {
 	// Get search and query parameters
 	const search = req.body.s ?? '';
-	const query = teamsService.updateMemberFilter(
+	const query = TeamsService.updateMemberFilter(
 		utilService.toMongoose(req.body.q ?? {}),
 		req.team
 	);
 
-	const results = await userService.searchUsers(req.query, query, search);
+	const results = await UserService.searchUsers(req.query, query, search);
 
 	// Create the return copy of the messages
 	const mappedResults = {
@@ -130,7 +129,7 @@ module.exports.searchMembers = async (req, res) => {
 		totalSize: results.totalSize,
 		elements: results.elements.map((element) => {
 			return {
-				...User.filteredCopy(element),
+				...UserModel.filteredCopy(element),
 				teams: element.teams.filter((team) => team._id === req.team._id)
 			};
 		})
@@ -142,10 +141,10 @@ module.exports.searchMembers = async (req, res) => {
 /**
  * Add a member to a team, defaulting to read-only access
  */
-module.exports.addMember = async (req, res) => {
+export const addMember = async (req, res) => {
 	const role = req.body.role ?? 'member';
 
-	await teamsService.addMemberToTeam(req.userParam, req.team, role);
+	await TeamsService.addMemberToTeam(req.userParam, req.team, role);
 
 	// Audit the member add request
 	await auditService.audit(
@@ -162,14 +161,14 @@ module.exports.addMember = async (req, res) => {
 /**
  * Add specified members with specified roles to a team
  */
-module.exports.addMembers = async (req, res) => {
+export const addMembers = async (req, res) => {
 	await Promise.all(
 		req.body.newMembers
 			.filter((member) => null != member._id)
 			.map(async (member) => {
-				const user = await userService.read(member._id);
+				const user = await UserService.read(member._id);
 				if (null != user) {
-					await teamsService.addMemberToTeam(user, req.team, member.role);
+					await TeamsService.addMemberToTeam(user, req.team, member.role);
 					return auditService.audit(
 						`team ${member.role} added`,
 						'team-role',
@@ -186,8 +185,8 @@ module.exports.addMembers = async (req, res) => {
 /**
  * Remove a member from a team
  */
-module.exports.removeMember = async (req, res) => {
-	await teamsService.removeMemberFromTeam(req.userParam, req.team);
+export const removeMember = async (req, res) => {
+	await TeamsService.removeMemberFromTeam(req.userParam, req.team);
 
 	// Audit the user remove
 	await auditService.audit(
@@ -201,10 +200,10 @@ module.exports.removeMember = async (req, res) => {
 	res.status(204).end();
 };
 
-module.exports.updateMemberRole = async (req, res) => {
+export const updateMemberRole = async (req, res) => {
 	const role = req.body.role || 'member';
 
-	await teamsService.updateMemberRole(req.userParam, req.team, role);
+	await TeamsService.updateMemberRole(req.userParam, req.team, role);
 
 	// Audit the member update request
 	await auditService.audit(
@@ -221,7 +220,7 @@ module.exports.updateMemberRole = async (req, res) => {
 /**
  * Team middleware
  */
-module.exports.teamById = async (req, res, next, id) => {
+export const teamById = async (req, res, next, id: string) => {
 	const populate = [
 		{
 			path: 'parent',
@@ -233,7 +232,7 @@ module.exports.teamById = async (req, res, next, id) => {
 		}
 	];
 
-	const team = await teamsService.read(id, populate);
+	const team = await TeamsService.read(id, populate);
 	if (!team) {
 		return next(new Error('Could not find team'));
 	}
@@ -241,8 +240,8 @@ module.exports.teamById = async (req, res, next, id) => {
 	return next();
 };
 
-module.exports.teamMemberById = async (req, res, next, id) => {
-	const user = await userService.read(id);
+export const teamMemberById = async (req, res, next, id: string) => {
+	const user = await UserService.read(id);
 
 	if (null == user) {
 		return next(new Error('Failed to load team member'));
@@ -254,7 +253,7 @@ module.exports.teamMemberById = async (req, res, next, id) => {
 /**
  * Does the user have the referenced role in the team
  */
-module.exports.requiresRole = function (role) {
+function requiresRole(role: TeamRoles): (req) => Promise<void> {
 	return function (req) {
 		// Verify that the user and team are on the request
 		const user = req.user;
@@ -274,18 +273,18 @@ module.exports.requiresRole = function (role) {
 			});
 		}
 
-		return teamsService.meetsRoleRequirement(user, team, role);
+		return TeamsService.meetsRoleRequirement(user, team, role);
 	};
+}
+
+export const requiresAdmin = (req) => {
+	return requiresRole(TeamRoles.Admin)(req);
 };
 
-exports.requiresAdmin = function (req) {
-	return module.exports.requiresRole('admin')(req);
+export const requiresEditor = (req) => {
+	return requiresRole(TeamRoles.Editor)(req);
 };
 
-exports.requiresEditor = function (req) {
-	return module.exports.requiresRole('editor')(req);
-};
-
-exports.requiresMember = function (req) {
-	return module.exports.requiresRole('member')(req);
+export const requiresMember = (req) => {
+	return requiresRole(TeamRoles.Member)(req);
 };

--- a/src/app/core/teams/teams.controller.ts
+++ b/src/app/core/teams/teams.controller.ts
@@ -142,7 +142,7 @@ export const searchMembers = async (req, res) => {
  * Add a member to a team, defaulting to read-only access
  */
 export const addMember = async (req, res) => {
-	const role = req.body.role ?? 'member';
+	const role: TeamRoles = req.body.role ?? TeamRoles.Member;
 
 	await TeamsService.addMemberToTeam(req.userParam, req.team, role);
 
@@ -201,7 +201,7 @@ export const removeMember = async (req, res) => {
 };
 
 export const updateMemberRole = async (req, res) => {
-	const role = req.body.role || 'member';
+	const role: TeamRoles = req.body.role || TeamRoles.Member;
 
 	await TeamsService.updateMemberRole(req.userParam, req.team, role);
 

--- a/src/app/core/teams/teams.routes.ts
+++ b/src/app/core/teams/teams.routes.ts
@@ -1,15 +1,13 @@
-'use strict';
+import { Router } from 'express';
+import { Validator } from 'express-json-validator-middleware';
 
-const express = require('express'),
-	{ Validator } = require('express-json-validator-middleware'),
-	teams = require('./teams.controller'),
-	user = require('../user/user.controller'),
-	teamSchemas = require('./teams.schemas');
+import * as user from '../user/user.controller';
+import * as teams from './teams.controller';
+import * as teamSchemas from './teams.schemas';
 
-// @ts-ignore
-const { validate } = new Validator();
+const { validate } = new Validator({});
 
-const router = express.Router();
+const router = Router();
 
 /**
  * @swagger
@@ -102,7 +100,7 @@ router
 	.delete(
 		user.hasAccess,
 		user.hasAny(user.requiresAdminRole, teams.requiresAdmin),
-		teams.delete
+		teams.deleteTeam
 	);
 
 /**
@@ -248,4 +246,4 @@ router
 router.param('teamId', teams.teamById);
 router.param('memberId', teams.teamMemberById);
 
-module.exports = router;
+export = router;

--- a/src/app/core/teams/teams.routes.ts
+++ b/src/app/core/teams/teams.routes.ts
@@ -209,6 +209,7 @@ router
 	.post(
 		user.hasAccess,
 		user.hasAny(user.requiresAdminRole, teams.requiresAdmin),
+		validate({ body: teamSchemas.addUpdateMemberRole }),
 		teams.addMember
 	)
 	.delete(
@@ -239,6 +240,7 @@ router
 	.post(
 		user.hasAccess,
 		user.hasAny(user.requiresAdminRole, teams.requiresAdmin),
+		validate({ body: teamSchemas.addUpdateMemberRole }),
 		teams.updateMemberRole
 	);
 

--- a/src/app/core/teams/teams.schemas.ts
+++ b/src/app/core/teams/teams.schemas.ts
@@ -1,8 +1,10 @@
 import JSONSchema7 from 'json-schema';
 
+import { TeamRoles } from './team-role.model';
+
 export const addMembers: JSONSchema7.JSONSchema7Object = {
 	$schema: 'http://json-schema.org/draft-07/schema',
-	$id: 'moniker-rest-server/src/app/core/team/addMembers',
+	$id: 'node-rest-server/src/app/core/team/addMembers',
 	type: 'object',
 	title: 'Team Add Members Schema',
 	description: 'Schema for adding members to a team',
@@ -21,11 +23,27 @@ export const addMembers: JSONSchema7.JSONSchema7Object = {
 						type: 'string'
 					},
 					role: {
-						type: 'string'
+						type: 'string',
+						enum: Object.values(TeamRoles)
 					}
 				}
 			},
 			minItems: 1
+		}
+	}
+};
+
+export const addUpdateMemberRole: JSONSchema7.JSONSchema7Object = {
+	$schema: 'http://json-schema.org/draft-07/schema',
+	$id: 'node-rest-server/src/app/core/team/addUpdateMemberRole',
+	type: 'object',
+	title: 'Team Add/Update Member Role Schema',
+	description: 'Schema for adding or updating a members role to a team',
+	required: ['role'],
+	properties: {
+		role: {
+			type: 'string',
+			enum: Object.values(TeamRoles)
 		}
 	}
 };

--- a/src/app/core/teams/teams.schemas.ts
+++ b/src/app/core/teams/teams.schemas.ts
@@ -1,7 +1,6 @@
-/**
- * @type {import('json-schema').JSONSchema7}
- */
-module.exports.addMembers = {
+import JSONSchema7 from 'json-schema';
+
+export const addMembers: JSONSchema7.JSONSchema7Object = {
 	$schema: 'http://json-schema.org/draft-07/schema',
 	$id: 'moniker-rest-server/src/app/core/team/addMembers',
 	type: 'object',

--- a/src/app/core/teams/teams.schemas.ts
+++ b/src/app/core/teams/teams.schemas.ts
@@ -1,8 +1,8 @@
-import JSONSchema7 from 'json-schema';
+import { JSONSchema7 } from 'json-schema';
 
 import { TeamRoles } from './team-role.model';
 
-export const addMembers: JSONSchema7.JSONSchema7Object = {
+export const addMembers: JSONSchema7 = {
 	$schema: 'http://json-schema.org/draft-07/schema',
 	$id: 'node-rest-server/src/app/core/team/addMembers',
 	type: 'object',
@@ -33,7 +33,7 @@ export const addMembers: JSONSchema7.JSONSchema7Object = {
 	}
 };
 
-export const addUpdateMemberRole: JSONSchema7.JSONSchema7Object = {
+export const addUpdateMemberRole: JSONSchema7 = {
 	$schema: 'http://json-schema.org/draft-07/schema',
 	$id: 'node-rest-server/src/app/core/team/addUpdateMemberRole',
 	type: 'object',

--- a/src/app/core/teams/teams.service.ts
+++ b/src/app/core/teams/teams.service.ts
@@ -390,21 +390,6 @@ class TeamsService {
 		});
 	}
 
-	/**
-	 * Validates that the roles are one of the accepted values
-	 */
-	validateTeamRole(role: string) {
-		if (-1 !== Object.keys(TeamRolePriorities).indexOf(role)) {
-			return Promise.resolve();
-		}
-
-		return Promise.reject({
-			status: 400,
-			type: 'bad-argument',
-			message: 'Team role does not exist'
-		});
-	}
-
 	private getImplicitMemberFilter(
 		team: TeamDocument
 	): FilterQuery<TeamDocument> {
@@ -537,8 +522,6 @@ class TeamsService {
 		if (currentRole === 'admin') {
 			await this.verifyNotLastAdmin(user, team);
 		}
-
-		await this.validateTeamRole(role);
 
 		return this.userModel
 			.findOneAndUpdate(

--- a/src/app/core/teams/teams.service.ts
+++ b/src/app/core/teams/teams.service.ts
@@ -11,7 +11,7 @@ import {
 import { PagingResults } from '../../common/mongoose/paginate.plugin';
 import userAuthService from '../user/auth/user-authorization.service';
 import { UserDocument } from '../user/types';
-import { TeamRolePriorities } from './team-role.model';
+import { TeamRolePriorities, TeamRoles } from './team-role.model';
 import { ITeam, TeamDocument, TeamModel } from './team.model';
 
 /**
@@ -71,7 +71,7 @@ class TeamsService {
 		const savedTeam = await newTeam.save();
 
 		// Add first admin as first team member with admin role, or the creator if null
-		await this.addMemberToTeam(user || creator, newTeam, 'admin');
+		await this.addMemberToTeam(user || creator, newTeam, TeamRoles.Admin);
 
 		return savedTeam;
 	}
@@ -257,7 +257,11 @@ class TeamsService {
 		);
 	}
 
-	meetsRoleRequirement(user: UserDocument, team: TeamDocument, role: string) {
+	meetsRoleRequirement(
+		user: UserDocument,
+		team: TeamDocument,
+		role: TeamRoles
+	): Promise<void> {
 		// Check role of the user in this team
 		const userRole = this.getActiveTeamRole(user, team);
 
@@ -276,7 +280,7 @@ class TeamsService {
 	 * Checks if user role meets or exceeds the requestedRole according to
 	 * a pre-defined role hierarchy
 	 */
-	meetsOrExceedsRole(userRole: string, requestedRole: string): boolean {
+	meetsOrExceedsRole(userRole: string, requestedRole: TeamRoles): boolean {
 		if (
 			null != userRole &&
 			_.has(TeamRolePriorities, userRole) &&
@@ -329,7 +333,7 @@ class TeamsService {
 	 * @param team The team object of interest
 	 * @returns A promise that resolves if there are no more resources in the team, and rejects otherwise
 	 */
-	async verifyNoResourcesInTeam(team) {
+	async verifyNoResourcesInTeam(team: TeamDocument): Promise<void> {
 		const resourceCount = await this.getResourceCount(team);
 
 		if (resourceCount > 0) {
@@ -401,7 +405,9 @@ class TeamsService {
 		});
 	}
 
-	getImplicitMemberFilter(team: TeamDocument): FilterQuery<TeamDocument> {
+	private getImplicitMemberFilter(
+		team: TeamDocument
+	): FilterQuery<TeamDocument> {
 		const implicitTeamStrategy =
 			config?.teams?.implicitMembers?.strategy ?? null;
 		if (
@@ -431,7 +437,8 @@ class TeamsService {
 	updateMemberFilter(query: FilterQuery<UserDocument>, team: TeamDocument) {
 		// Extract member types and roles for filtering
 		const types = query.$and?.find((filter) => filter.type)?.type.$in ?? [];
-		const roles = query.$and?.find((filter) => filter.role)?.role.$in ?? [];
+		const roles: TeamRoles[] =
+			query.$and?.find((filter) => filter.role)?.role.$in ?? [];
 
 		// Remove member types and roles filters from query
 		_.remove(query.$and, (filter) => filter.type || filter.role);
@@ -447,7 +454,10 @@ class TeamsService {
 			}
 			query.$or.push({ 'teams._id': team._id });
 		} else if (types.length > 0 && roles.length > 0) {
-			if (types.indexOf('implicit') !== -1 && roles.indexOf('member') !== -1) {
+			if (
+				types.indexOf('implicit') !== -1 &&
+				roles.indexOf(TeamRoles.Member) !== -1
+			) {
 				const implicitFilter = this.getImplicitMemberFilter(team);
 				if (implicitFilter) {
 					query.$or.push(implicitFilter);
@@ -469,7 +479,7 @@ class TeamsService {
 				query.$or.push({ 'teams._id': team._id });
 			}
 		} /* roles.length > 0 */ else {
-			if (roles.indexOf('member') !== -1) {
+			if (roles.indexOf(TeamRoles.Member) !== -1) {
 				const implicitFilter = this.getImplicitMemberFilter(team);
 				if (implicitFilter) {
 					query.$or.push(implicitFilter);
@@ -500,7 +510,7 @@ class TeamsService {
 	addMemberToTeam(
 		user: UserDocument,
 		team: TeamDocument,
-		role: string
+		role: TeamRoles
 	): Promise<UserDocument> {
 		return this.userModel
 			.findOneAndUpdate(
@@ -520,7 +530,7 @@ class TeamsService {
 	async updateMemberRole(
 		user: UserDocument,
 		team: TeamDocument,
-		role: string
+		role: TeamRoles
 	): Promise<UserDocument> {
 		const currentRole = this.getTeamRole(user, team);
 
@@ -602,7 +612,7 @@ class TeamsService {
 				teams: {
 					$elemMatch: {
 						_id: new mongoose.Types.ObjectId(team._id),
-						role: 'admin'
+						role: TeamRoles.Admin
 					}
 				}
 			})
@@ -618,7 +628,7 @@ class TeamsService {
 		}
 
 		// Add requester role to user for this team
-		await this.addMemberToTeam(requester, team, 'requester');
+		await this.addMemberToTeam(requester, team, TeamRoles.Requester);
 
 		// Email template rendering requires simple objects and not Mongo classes
 		return this.sendRequestEmail(adminEmails, requester, team, req);
@@ -671,7 +681,7 @@ class TeamsService {
 
 	getExplicitTeamIds(
 		user: UserDocument,
-		...roles: string[]
+		...roles: TeamRoles[]
 	): Promise<Types.ObjectId[]> {
 		// Validate the user input
 		if (null == user) {
@@ -696,7 +706,7 @@ class TeamsService {
 
 	async getImplicitTeamIds(
 		user: UserDocument,
-		...roles: string[]
+		...roles: TeamRoles[]
 	): Promise<Types.ObjectId[]> {
 		// Validate the user input
 		if (null == user) {
@@ -709,7 +719,10 @@ class TeamsService {
 
 		const strategy = config?.teams?.implicitMembers?.strategy ?? null;
 
-		if (strategy == null || (roles.length > 0 && !roles.includes('member'))) {
+		if (
+			strategy == null ||
+			(roles.length > 0 && !roles.includes(TeamRoles.Member))
+		) {
 			return Promise.resolve([]);
 		}
 
@@ -757,7 +770,10 @@ class TeamsService {
 			return Promise.resolve([]);
 		}
 
-		const blockedTeamIds = await this.getExplicitTeamIds(user, 'blocked');
+		const blockedTeamIds = await this.getExplicitTeamIds(
+			user,
+			TeamRoles.Blocked
+		);
 		if (blockedTeamIds.length > 0) {
 			query.$and.push({
 				_id: { $nin: blockedTeamIds }
@@ -789,7 +805,7 @@ class TeamsService {
 
 	async getTeamIds(
 		user: UserDocument,
-		...roles: string[]
+		...roles: TeamRoles[]
 	): Promise<Types.ObjectId[]> {
 		const explicitTeamIds = await this.getExplicitTeamIds(user, ...roles);
 		const implicitTeamIds = await this.getImplicitTeamIds(user, ...roles);
@@ -803,15 +819,20 @@ class TeamsService {
 	}
 
 	getMemberTeamIds(user: UserDocument): Promise<Types.ObjectId[]> {
-		return this.getTeamIds(user, 'member', 'editor', 'admin');
+		return this.getTeamIds(
+			user,
+			TeamRoles.Member,
+			TeamRoles.Editor,
+			TeamRoles.Admin
+		);
 	}
 
 	getEditorTeamIds(user: UserDocument): Promise<Types.ObjectId[]> {
-		return this.getTeamIds(user, 'editor', 'admin');
+		return this.getTeamIds(user, TeamRoles.Editor, TeamRoles.Admin);
 	}
 
 	getAdminTeamIds(user: UserDocument): Promise<Types.ObjectId[]> {
-		return this.getTeamIds(user, 'admin');
+		return this.getTeamIds(user, TeamRoles.Admin);
 	}
 
 	/**
@@ -840,9 +861,9 @@ class TeamsService {
 		}
 
 		const [adminTeamIds, editorTeamIds, memberTeamIds] = await Promise.all([
-			this.getTeamIds(user, 'admin'),
-			this.getTeamIds(user, 'editor'),
-			this.getTeamIds(user, 'member')
+			this.getTeamIds(user, TeamRoles.Admin),
+			this.getTeamIds(user, TeamRoles.Editor),
+			this.getTeamIds(user, TeamRoles.Member)
 		]);
 
 		const filteredEditorTeamIds = _.differenceWith(
@@ -857,9 +878,15 @@ class TeamsService {
 		);
 
 		const updatedTeams = [
-			...adminTeamIds.map((id) => ({ role: 'admin', _id: id })),
-			...filteredEditorTeamIds.map((id) => ({ role: 'editor', _id: id })),
-			...filteredMemberTeamIds.map((id) => ({ role: 'member', _id: id }))
+			...adminTeamIds.map((id) => ({ role: TeamRoles.Admin, _id: id })),
+			...filteredEditorTeamIds.map((id) => ({
+				role: TeamRoles.Editor,
+				_id: id
+			})),
+			...filteredMemberTeamIds.map((id) => ({
+				role: TeamRoles.Member,
+				_id: id
+			}))
 		];
 
 		user.teams = updatedTeams;

--- a/src/app/core/user/types.d.ts
+++ b/src/app/core/user/types.d.ts
@@ -5,6 +5,7 @@ import { HydratedDocument, Model, Types } from 'mongoose';
 import { ContainsSearchable } from '../../common/mongoose/contains-search.plugin';
 import { Paginateable } from '../../common/mongoose/paginate.plugin';
 import { TextSearchable } from '../../common/mongoose/text-search.plugin';
+import { TeamRoles } from '../teams/team-role.model';
 
 type UserRoles = {
 	user?: boolean;
@@ -42,7 +43,7 @@ export interface IUser {
 	newFeatureDismissed: Date;
 	preferences: Record<string, unknown>;
 	salt: BinaryLike;
-	teams: { _id: Types.ObjectId; role: string }[];
+	teams: { _id: Types.ObjectId; role: TeamRoles }[];
 }
 
 interface IUserMethods {


### PR DESCRIPTION
Converts the remaining parts of the Teams Module to typescript.

Switches over from strings for team roles to the TeamRoles enum.