### PR TITLE
fix(teams): Ensure team roles are returned when returning team member…

### DIFF
--- a/src/app/core/teams/teams.controller.ts
+++ b/src/app/core/teams/teams.controller.ts
@@ -130,7 +130,7 @@ export const searchMembers = async (req, res) => {
 		elements: results.elements.map((element) => {
 			return {
 				...User.filteredCopy(element),
-				teams: element.teams.filter((team) => team._id === req.team._id)
+				teams: element.teams.filter((team) => team._id.equals(req.team._id))
 			};
 		})
 	};


### PR DESCRIPTION
…s list

Improper comparison of Mongo ObjectIDs was resulting in the team roles not returning.