### PR TITLE
refactor: Simplify accessing mongoose models

### DIFF
--- a/src/app/core/access-checker/access-checker.service.spec.ts
+++ b/src/app/core/access-checker/access-checker.service.spec.ts
@@ -4,11 +4,9 @@ import should from 'should';
 import { createSandbox } from 'sinon';
 
 import accessChecker from './access-checker.service';
-import { CacheEntryModel, ICacheEntry } from './cache/cache-entry.model';
+import { CacheEntry, ICacheEntry } from './cache/cache-entry.model';
 import cacheEntryService from './cache/cache-entry.service';
-import { config, dbs } from '../../../dependencies';
-
-const CacheEntry = dbs.admin.model('CacheEntry') as CacheEntryModel;
+import { config } from '../../../dependencies';
 
 /**
  * Helpers

--- a/src/app/core/access-checker/cache/cache-entry.service.spec.ts
+++ b/src/app/core/access-checker/cache/cache-entry.service.spec.ts
@@ -1,10 +1,7 @@
 import should from 'should';
 
-import { CacheEntryModel } from './cache-entry.model';
+import { CacheEntry } from './cache-entry.model';
 import cacheEntryService from './cache-entry.service';
-import { dbs } from '../../../../dependencies';
-
-const CacheEntry = dbs.admin.model('CacheEntry') as CacheEntryModel;
 
 /**
  * Unit tests

--- a/src/app/core/access-checker/cache/cache-entry.service.ts
+++ b/src/app/core/access-checker/cache/cache-entry.service.ts
@@ -1,15 +1,15 @@
 import { FilterQuery } from 'mongoose';
 
-import { CacheEntryDocument, CacheEntryModel } from './cache-entry.model';
-import { dbs, utilService } from '../../../../dependencies';
+import {
+	CacheEntry,
+	CacheEntryDocument,
+	CacheEntryModel
+} from './cache-entry.model';
+import { utilService } from '../../../../dependencies';
 import { PagingResults } from '../../../common/mongoose/paginate.plugin';
 
 class CacheEntryService {
-	model: CacheEntryModel;
-
-	constructor() {
-		this.model = dbs.admin.model('CacheEntry') as CacheEntryModel;
-	}
+	constructor(private model: CacheEntryModel) {}
 
 	/**
 	 * Get the entry from the cache. Gets the most recent version.
@@ -68,4 +68,4 @@ class CacheEntryService {
 	}
 }
 
-export = new CacheEntryService();
+export = new CacheEntryService(CacheEntry);

--- a/src/app/core/access-checker/cache/cache-refresh.job.ts
+++ b/src/app/core/access-checker/cache/cache-refresh.job.ts
@@ -1,11 +1,9 @@
 import { Job } from 'agenda';
 
-import { CacheEntryModel } from './cache-entry.model';
-import { dbs, logger } from '../../../../dependencies';
+import { CacheEntry } from './cache-entry.model';
+import { logger } from '../../../../dependencies';
 import { JobService } from '../../../common/agenda/job-service';
 import accessChecker from '../access-checker.service';
-
-const CacheEntry = dbs.admin.model('CacheEntry') as CacheEntryModel;
 
 export default class CacheRefreshJobService implements JobService {
 	async run(job: Job) {

--- a/src/app/core/audit/audit.controller.ts
+++ b/src/app/core/audit/audit.controller.ts
@@ -1,9 +1,7 @@
 import _ from 'lodash';
 
-import { AuditModel } from './audit.model';
-import { dbs, utilService as util } from '../../../dependencies';
-
-const Audit = dbs.admin.model('Audit') as AuditModel;
+import { Audit } from './audit.model';
+import { utilService as util } from '../../../dependencies';
 
 /**
  * Retrieves the distinct values for a field in the Audit collection

--- a/src/app/core/audit/audit.service.spec.ts
+++ b/src/app/core/audit/audit.service.spec.ts
@@ -1,11 +1,8 @@
 import should from 'should';
 
-import { AuditModel } from './audit.model';
+import { Audit } from './audit.model';
 import auditService from './audit.service';
-import { dbs } from '../../../dependencies';
 import { IUser } from '../user/user.model';
-
-const Audit = dbs.admin.model('Audit') as AuditModel;
 
 /**
  * Globals

--- a/src/app/core/audit/audit.service.ts
+++ b/src/app/core/audit/audit.service.ts
@@ -1,8 +1,7 @@
 import { Request } from 'express';
 
-import { AuditDocument, AuditModel } from './audit.model';
+import { Audit, AuditDocument } from './audit.model';
 import {
-	dbs,
 	config,
 	logger,
 	auditLogger,
@@ -34,9 +33,6 @@ class AuditService {
 		eventObject: unknown,
 		eventMetadata = null
 	): Promise<AuditDocument> {
-		// Delay resolving the Audit model until we can be sure it has been initialized
-		const Audit = dbs.admin.model('Audit') as AuditModel;
-
 		requestOrEventActor = await requestOrEventActor;
 
 		let actor = {};
@@ -44,7 +40,7 @@ class AuditService {
 			actor = requestOrEventActor;
 		} else if (requestOrEventActor.user && requestOrEventActor.headers) {
 			const user = requestOrEventActor.user as UserDocument;
-			actor = await user.auditCopy(
+			actor = user.auditCopy(
 				utilService.getHeaderField(requestOrEventActor.headers, 'x-real-ip')
 			);
 			eventMetadata = requestOrEventActor.headers;

--- a/src/app/core/export/export-config.model.ts
+++ b/src/app/core/export/export-config.model.ts
@@ -77,7 +77,7 @@ ExportConfigSchema.methods.auditCopy = function () {
 /**
  * Model Registration
  */
-export const Message = model<IExportConfig, ExportConfigModel>(
+export const ExportConfig = model<IExportConfig, ExportConfigModel>(
 	'ExportConfig',
 	ExportConfigSchema
 );

--- a/src/app/core/export/export-config.service.ts
+++ b/src/app/core/export/export-config.service.ts
@@ -1,10 +1,13 @@
 import { Types } from 'mongoose';
 
-import { ExportConfigDocument, ExportConfigModel } from './export-config.model';
-import { dbs } from '../../../dependencies';
+import {
+	ExportConfig,
+	ExportConfigDocument,
+	ExportConfigModel
+} from './export-config.model';
 
 class ExportConfigService {
-	model = dbs.admin.model('ExportConfig') as ExportConfigModel;
+	constructor(private model: ExportConfigModel) {}
 
 	/**
 	 * Generate a new ExportConfig document in the collection.
@@ -22,4 +25,4 @@ class ExportConfigService {
 	}
 }
 
-export = new ExportConfigService();
+export = new ExportConfigService(ExportConfig);

--- a/src/app/core/feedback/feedback.controller.spec.ts
+++ b/src/app/core/feedback/feedback.controller.spec.ts
@@ -1,13 +1,10 @@
 import { assert, createSandbox, spy, stub } from 'sinon';
 
 import * as feedbackController from './feedback.controller';
-import { FeedbackModel } from './feedback.model';
+import { Feedback } from './feedback.model';
 import feedbackService from './feedback.service';
-import { auditService, dbs, logger } from '../../../dependencies';
-import { UserModel } from '../user/user.model';
-
-const Feedback = dbs.admin.model('Feedback') as FeedbackModel;
-const User = dbs.admin.model('User') as UserModel;
+import { auditService, logger } from '../../../dependencies';
+import { User } from '../user/user.model';
 
 describe('Feedback Controller2', () => {
 	let res;

--- a/src/app/core/feedback/feedback.service.spec.ts
+++ b/src/app/core/feedback/feedback.service.spec.ts
@@ -1,13 +1,10 @@
 import should from 'should';
 import { assert, createSandbox } from 'sinon';
 
-import { FeedbackModel } from './feedback.model';
+import { Feedback } from './feedback.model';
 import feedbackService from './feedback.service';
-import { auditService, emailService, config, dbs } from '../../../dependencies';
-import { UserModel } from '../user/user.model';
-
-const User = dbs.admin.model('User') as UserModel;
-const Feedback = dbs.admin.model('Feedback') as FeedbackModel;
+import { auditService, emailService, config } from '../../../dependencies';
+import { User } from '../user/user.model';
 
 /**
  * Unit tests

--- a/src/app/core/messages/messages.service.spec.ts
+++ b/src/app/core/messages/messages.service.spec.ts
@@ -1,17 +1,10 @@
 import mongoose from 'mongoose';
 import should from 'should';
 
-import { DismissedMessageModel } from './dismissed-message.model';
-import { MessageModel } from './message.model';
+import { DismissedMessage } from './dismissed-message.model';
+import { Message } from './message.model';
 import messagesService from './messages.service';
-import { dbs } from '../../../dependencies';
-import { UserModel } from '../user/user.model';
-
-const User = dbs.admin.model('User') as UserModel;
-const Message = dbs.admin.model('Message') as MessageModel;
-const DismissedMessage = dbs.admin.model(
-	'DismissedMessage'
-) as DismissedMessageModel;
+import { User } from '../user/user.model';
 
 /**
  * Helpers

--- a/src/app/core/messages/messages.service.ts
+++ b/src/app/core/messages/messages.service.ts
@@ -3,27 +3,29 @@ import path from 'path';
 import { FilterQuery, PopulateOptions, Types } from 'mongoose';
 
 import {
+	DismissedMessage,
 	DismissedMessageDocument,
 	DismissedMessageModel,
 	IDismissedMessage
 } from './dismissed-message.model';
-import { IMessage, MessageDocument, MessageModel } from './message.model';
-import { dbs, config, utilService } from '../../../dependencies';
+import {
+	IMessage,
+	Message,
+	MessageDocument,
+	MessageModel
+} from './message.model';
+import { config, utilService } from '../../../dependencies';
 import { PublishProvider } from '../../common/event/publish.provider';
 import { PagingResults } from '../../common/mongoose/paginate.plugin';
 import { UserDocument } from '../user/user.model';
 
 class MessagesService {
-	model: MessageModel;
-	dismissedModel: DismissedMessageModel;
 	publishProvider: PublishProvider;
 
-	constructor() {
-		this.model = dbs.admin.model('Message') as MessageModel;
-		this.dismissedModel = dbs.admin.model(
-			'DismissedMessage'
-		) as DismissedMessageModel;
-	}
+	constructor(
+		private model: MessageModel,
+		private dismissedModel: DismissedMessageModel
+	) {}
 
 	create(user: UserDocument, doc: unknown): Promise<MessageDocument> {
 		const message = new this.model(doc);
@@ -144,4 +146,4 @@ class MessagesService {
 	}
 }
 
-export = new MessagesService();
+export = new MessagesService(Message, DismissedMessage);

--- a/src/app/core/notifications/notification.service.ts
+++ b/src/app/core/notifications/notification.service.ts
@@ -1,15 +1,15 @@
 import { FilterQuery } from 'mongoose';
 
-import { NotificationDocument, NotificationModel } from './notification.model';
-import { dbs, utilService } from '../../../dependencies';
+import {
+	Notification,
+	NotificationDocument,
+	NotificationModel
+} from './notification.model';
+import { utilService } from '../../../dependencies';
 import { PagingResults } from '../../common/mongoose/paginate.plugin';
 
 class NotificationService {
-	model: NotificationModel;
-
-	constructor() {
-		this.model = dbs.admin.model('Notification') as NotificationModel;
-	}
+	constructor(private model: NotificationModel) {}
 
 	search(
 		queryParams = {},
@@ -24,4 +24,4 @@ class NotificationService {
 	}
 }
 
-export = new NotificationService();
+export = new NotificationService(Notification);

--- a/src/app/core/teams/team.model.spec.ts
+++ b/src/app/core/teams/team.model.spec.ts
@@ -1,14 +1,9 @@
 import should from 'should';
 
 import { TeamRoles } from './team-role.model';
-import { TeamModel } from './team.model';
-import { dbs } from '../../../dependencies';
-import { AuditModel } from '../audit/audit.model';
-import { UserModel } from '../user/user.model';
-
-const Audit = dbs.admin.model('Audit') as AuditModel;
-const Team = dbs.admin.model('Team') as TeamModel;
-const User = dbs.admin.model('User') as UserModel;
+import { Team } from './team.model';
+import { Audit } from '../audit/audit.model';
+import { User } from '../user/user.model';
 
 /**
  * Globals

--- a/src/app/core/teams/teams.controller.spec.ts
+++ b/src/app/core/teams/teams.controller.spec.ts
@@ -2,15 +2,12 @@ import { Request } from 'express';
 import should from 'should';
 import { assert, createSandbox, match, spy, stub } from 'sinon';
 
-import { TeamDocument, TeamModel } from './team.model';
+import { Team, TeamDocument } from './team.model';
 import * as teamsController from './teams.controller';
 import teamsService from './teams.service';
-import { auditService, dbs, logger } from '../../../dependencies';
-import { UserDocument, UserModel } from '../user/user.model';
+import { auditService, logger } from '../../../dependencies';
+import { User, UserDocument } from '../user/user.model';
 import userService from '../user/user.service';
-
-const Team = dbs.admin.model('Team') as TeamModel;
-const User = dbs.admin.model('User') as UserModel;
 
 /**
  * Unit tests

--- a/src/app/core/teams/teams.service.spec.ts
+++ b/src/app/core/teams/teams.service.spec.ts
@@ -4,20 +4,16 @@ import should from 'should';
 import { assert, createSandbox } from 'sinon';
 
 import { TeamRoles } from './team-role.model';
-import { ITeam, TeamDocument, TeamModel } from './team.model';
+import { ITeam, Team, TeamDocument } from './team.model';
 import teamsService from './teams.service';
 import {
 	auditService,
 	config,
-	dbs,
 	emailService,
 	logger
 } from '../../../dependencies';
-import { IUser, UserDocument, UserModel } from '../user/user.model';
+import { IUser, User, UserDocument } from '../user/user.model';
 import userService from '../user/user.service';
-
-const User = dbs.admin.model('User') as UserModel;
-const Team = dbs.admin.model('Team') as TeamModel;
 
 /**
  * Helpers

--- a/src/app/core/teams/teams.service.ts
+++ b/src/app/core/teams/teams.service.ts
@@ -7,10 +7,9 @@ import {
 	TeamRolePriorities,
 	TeamRoles
 } from './team-role.model';
-import { ITeam, TeamDocument, TeamModel } from './team.model';
+import { ITeam, TeamDocument, TeamModel, Team } from './team.model';
 import {
 	config,
-	dbs,
 	emailService,
 	logger,
 	utilService
@@ -18,7 +17,7 @@ import {
 import { PagingResults } from '../../common/mongoose/paginate.plugin';
 import { IdOrObject, Override } from '../../common/typescript-util';
 import userAuthService from '../user/auth/user-authorization.service';
-import { IUser, UserDocument, UserModel } from '../user/user.model';
+import { IUser, UserDocument, UserModel, User } from '../user/user.model';
 
 /**
  * Copies the mutable fields from src to dest
@@ -36,13 +35,10 @@ const isObjectIdEqual = (value1, value2) => {
 };
 
 class TeamsService {
-	model: TeamModel;
-	userModel: UserModel;
-
-	constructor() {
-		this.model = dbs.admin.model('Team') as TeamModel;
-		this.userModel = dbs.admin.model('User') as UserModel;
-	}
+	constructor(
+		private model: TeamModel,
+		private userModel: UserModel
+	) {}
 
 	/**
 	 * Creates a new team with the requested metadata
@@ -879,4 +875,4 @@ class TeamsService {
 	}
 }
 
-export = new TeamsService();
+export = new TeamsService(Team, User);

--- a/src/app/core/user/admin/user-admin.controller.spec.ts
+++ b/src/app/core/user/admin/user-admin.controller.spec.ts
@@ -1,14 +1,10 @@
-'use strict';
-
 import { assert, createSandbox, spy, stub } from 'sinon';
 
 import * as userAdminController from './user-admin.controller';
-import { auditService, config, dbs } from '../../../../dependencies';
+import { auditService, config } from '../../../../dependencies';
 import userEmailService from '../user-email.service';
-import { UserModel } from '../user.model';
+import { User } from '../user.model';
 import userService from '../user.service';
-
-const User = dbs.admin.model('User') as UserModel;
 
 /**
  * Helpers

--- a/src/app/core/user/auth/user-authentication.controller.spec.ts
+++ b/src/app/core/user/auth/user-authentication.controller.spec.ts
@@ -4,17 +4,14 @@ import passport from 'passport';
 import should from 'should';
 
 import * as userAuthenticationController from './user-authentication.controller';
-import { config, dbs } from '../../../../dependencies';
+import { config } from '../../../../dependencies';
 import local from '../../../../lib/strategies/local';
 import proxyPki from '../../../../lib/strategies/proxy-pki';
 import {
-	CacheEntryModel,
+	CacheEntry,
 	ICacheEntry
 } from '../../access-checker/cache/cache-entry.model';
-import { IUser, UserModel } from '../user.model';
-
-const User = dbs.admin.model('User') as UserModel;
-const CacheEntry = dbs.admin.model('CacheEntry') as CacheEntryModel;
+import { IUser, User } from '../user.model';
 
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 const emptyFn = () => {};

--- a/src/app/core/user/auth/user-authentication.controller.ts
+++ b/src/app/core/user/auth/user-authentication.controller.ts
@@ -1,11 +1,9 @@
 import userAuthService from './user-authentication.service';
 import userAuthorizationService from './user-authorization.service';
-import { auditService, config, dbs } from '../../../../dependencies';
+import { auditService, config } from '../../../../dependencies';
 import teamService from '../../teams/teams.service';
 import userEmailService from '../user-email.service';
-import { UserDocument, UserModel } from '../user.model';
-
-const User = dbs.admin.model('User') as UserModel;
+import { UserDocument, User } from '../user.model';
 
 /**
  * ==========================================================

--- a/src/app/core/user/auth/user-authorization.service.spec.ts
+++ b/src/app/core/user/auth/user-authorization.service.spec.ts
@@ -3,10 +3,8 @@ import should from 'should';
 import { createSandbox } from 'sinon';
 
 import userAuthorizationService from './user-authorization.service';
-import { config, dbs } from '../../../../dependencies';
-import { IUser, UserModel } from '../user.model';
-
-const User = dbs.admin.model('User') as UserModel;
+import { config } from '../../../../dependencies';
+import { IUser, User } from '../user.model';
 
 function userSpec(key) {
 	return {

--- a/src/app/core/user/auth/user-password.service.spec.ts
+++ b/src/app/core/user/auth/user-password.service.spec.ts
@@ -4,10 +4,8 @@ import should from 'should';
 import { assert, createSandbox } from 'sinon';
 
 import userPasswordService from './user-password.service';
-import { config, dbs, emailService, logger } from '../../../../dependencies';
-import { UserModel } from '../user.model';
-
-const User = dbs.admin.model('User') as UserModel;
+import { config, emailService, logger } from '../../../../dependencies';
+import { User } from '../user.model';
 
 /**
  * Unit tests

--- a/src/app/core/user/auth/user-password.service.ts
+++ b/src/app/core/user/auth/user-password.service.ts
@@ -3,12 +3,12 @@ import { promisify } from 'util';
 
 import { DateTime } from 'luxon';
 
-import { config, dbs, emailService, logger } from '../../../../dependencies';
-import { UserDocument, UserModel } from '../user.model';
-
-const User = dbs.admin.model('User') as UserModel;
+import { config, emailService, logger } from '../../../../dependencies';
+import { User, UserDocument, UserModel } from '../user.model';
 
 class UserPasswordService {
+	constructor(private userModel: UserModel) {}
+
 	findUserForActiveToken(token: string) {
 		return User.findOne({
 			resetPasswordToken: token,
@@ -122,4 +122,4 @@ class UserPasswordService {
 	}
 }
 
-export = new UserPasswordService();
+export = new UserPasswordService(User);

--- a/src/app/core/user/eua/eua.controller.spec.ts
+++ b/src/app/core/user/eua/eua.controller.spec.ts
@@ -5,10 +5,8 @@ import { assert, createSandbox, match, spy, stub } from 'sinon';
 import * as euaController from './eua.controller';
 import { UserAgreement, UserAgreementDocument } from './eua.model';
 import euaService from './eua.service';
-import { auditService, dbs, logger } from '../../../../dependencies';
-import { UserModel } from '../user.model';
-
-const User = dbs.admin.model('User') as UserModel;
+import { auditService, logger } from '../../../../dependencies';
+import { User } from '../user.model';
 
 /**
  * Unit tests

--- a/src/app/core/user/eua/eua.service.spec.ts
+++ b/src/app/core/user/eua/eua.service.spec.ts
@@ -1,12 +1,8 @@
 import should from 'should';
 
-import { UserAgreementModel } from './eua.model';
+import { UserAgreement } from './eua.model';
 import euaService from './eua.service';
-import { dbs } from '../../../../dependencies';
-import { UserModel } from '../user.model';
-
-const User = dbs.admin.model('User') as UserModel;
-const UserAgreement = dbs.admin.model('UserAgreement') as UserAgreementModel;
+import { User } from '../user.model';
 
 /**
  * Unit tests

--- a/src/app/core/user/eua/eua.service.ts
+++ b/src/app/core/user/eua/eua.service.ts
@@ -3,18 +3,15 @@ import { FilterQuery, PopulateOptions, Types } from 'mongoose';
 import {
 	IUserAgreement,
 	UserAgreementDocument,
-	UserAgreementModel
+	UserAgreementModel,
+	UserAgreement
 } from './eua.model';
-import { dbs, utilService } from '../../../../dependencies';
+import { utilService } from '../../../../dependencies';
 import { PagingResults } from '../../../common/mongoose/paginate.plugin';
 import { UserDocument } from '../user.model';
 
 class EuaService {
-	model: UserAgreementModel;
-
-	constructor() {
-		this.model = dbs.admin.model('UserAgreement') as UserAgreementModel;
-	}
+	constructor(private model: UserAgreementModel) {}
 
 	create(doc: unknown): Promise<UserAgreementDocument> {
 		const document = new this.model(doc);
@@ -88,4 +85,4 @@ class EuaService {
 	}
 }
 
-export = new EuaService();
+export = new EuaService(UserAgreement);

--- a/src/app/core/user/inactive/inactive-user.job.ts
+++ b/src/app/core/user/inactive/inactive-user.job.ts
@@ -1,21 +1,16 @@
-'use strict';
-
 import { Job } from 'agenda';
 import _ from 'lodash';
 import { DateTime } from 'luxon';
 import { FilterQuery } from 'mongoose';
 
 import {
-	dbs,
 	config,
 	emailService,
 	auditService,
 	logger
 } from '../../../../dependencies';
 import { JobService } from '../../../common/agenda/job-service';
-import { UserDocument, UserModel } from '../user.model';
-
-const User = dbs.admin.model('User') as UserModel;
+import { User, UserDocument } from '../user.model';
 
 /**
  * alert users whose accounts have been inactive for 30-89 days. Remove accounts that have been inactive for 90+ days

--- a/src/app/core/user/user-email.service.spec.ts
+++ b/src/app/core/user/user-email.service.spec.ts
@@ -1,11 +1,9 @@
 import { assert, createSandbox } from 'sinon';
 
 import userEmailService from './user-email.service';
-import { UserModel } from './user.model';
+import { User } from './user.model';
 import userService from './user.service';
-import { config, dbs, emailService, logger } from '../../../dependencies';
-
-const User = dbs.admin.model('User') as UserModel;
+import { config, emailService, logger } from '../../../dependencies';
 
 /**
  * Unit tests

--- a/src/app/core/user/user.controller.spec.ts
+++ b/src/app/core/user/user.controller.spec.ts
@@ -3,11 +3,9 @@ import { assert, createSandbox, spy, stub } from 'sinon';
 
 import userAuthorizationService from './auth/user-authorization.service';
 import * as userController from './user.controller';
-import { UserModel } from './user.model';
+import { User } from './user.model';
 import userService from './user.service';
-import { auditService, config, dbs, logger } from '../../../dependencies';
-
-const User = dbs.admin.model('User') as UserModel;
+import { auditService, config, logger } from '../../../dependencies';
 
 /**
  * Unit tests
@@ -77,9 +75,7 @@ describe('User Profile Controller:', () => {
 				}
 			};
 
-			sandbox.stub(User, 'findById').returns({
-				exec: () => Promise.resolve(user)
-			});
+			sandbox.stub(userService, 'read').resolves(user);
 			sandbox.stub(auditService, 'audit').resolves();
 
 			await userController.updateCurrentUser(req, res);
@@ -104,10 +100,9 @@ describe('User Profile Controller:', () => {
 					callback();
 				}
 			};
+			user.auditCopy();
 
-			sandbox.stub(User, 'findById').returns({
-				exec: () => Promise.resolve(user)
-			});
+			sandbox.stub(userService, 'read').resolves(user);
 			sandbox.stub(auditService, 'audit').resolves();
 
 			await userController.updateCurrentUser(req, res);
@@ -130,9 +125,7 @@ describe('User Profile Controller:', () => {
 				user: user
 			};
 
-			sandbox.stub(User, 'findById').returns({
-				exec: () => Promise.resolve(user)
-			});
+			sandbox.stub(userService, 'read').resolves(user);
 			sandbox.stub(auditService, 'audit').resolves();
 
 			await userController.updateCurrentUser(req, res);
@@ -158,9 +151,7 @@ describe('User Profile Controller:', () => {
 				}
 			};
 
-			sandbox.stub(User, 'findById').returns({
-				exec: () => Promise.resolve(user)
-			});
+			sandbox.stub(userService, 'read').resolves(user);
 			sandbox.stub(auditService, 'audit').resolves();
 
 			await userController.updateCurrentUser(req, res);
@@ -186,9 +177,7 @@ describe('User Profile Controller:', () => {
 				}
 			};
 
-			sandbox.stub(User, 'findById').returns({
-				exec: () => Promise.resolve(user)
-			});
+			sandbox.stub(userService, 'read').resolves(user);
 			sandbox.stub(auditService, 'audit').resolves();
 
 			await userController.updateCurrentUser(req, res);

--- a/src/app/core/user/user.controller.ts
+++ b/src/app/core/user/user.controller.ts
@@ -1,12 +1,9 @@
 import _ from 'lodash';
 
 import userAuthorizationService from './auth/user-authorization.service';
-import { UserModel } from './user.model';
 import userService from './user.service';
-import { auditService, config, dbs, utilService } from '../../../dependencies';
+import { auditService, config, utilService } from '../../../dependencies';
 import teamService from '../teams/teams.service';
-
-const User = dbs.admin.model('User') as UserModel;
 
 /**
  * Standard User Operations
@@ -43,7 +40,7 @@ export const updateCurrentUser = async (req, res) => {
 	}
 
 	// Get the full user (including the password)
-	const user = await User.findById(req.user._id).exec();
+	const user = await userService.read(req.user._id);
 	const originalUser = user.auditCopy();
 
 	// Copy over the new user properties

--- a/src/app/core/user/user.model.spec.ts
+++ b/src/app/core/user/user.model.spec.ts
@@ -3,10 +3,7 @@ import * as assert from 'assert';
 import { Types } from 'mongoose';
 import should from 'should';
 
-import { UserModel } from './user.model';
-import { dbs } from '../../../dependencies';
-
-const User = dbs.admin.model('User') as UserModel;
+import { User } from './user.model';
 
 /**
  * Globals

--- a/src/app/core/user/user.service.spec.ts
+++ b/src/app/core/user/user.service.spec.ts
@@ -1,10 +1,7 @@
 import should from 'should';
 
-import { UserModel } from './user.model';
+import { User } from './user.model';
 import userService from './user.service';
-import { dbs } from '../../../dependencies';
-
-const User = dbs.admin.model('User') as UserModel;
 
 /**
  * Helpers

--- a/src/lib/mongoose.spec.ts
+++ b/src/lib/mongoose.spec.ts
@@ -1,3 +1,4 @@
+import { intersection } from 'lodash';
 import { Connection, Mongoose } from 'mongoose';
 import { createSandbox } from 'sinon';
 
@@ -71,6 +72,17 @@ describe('Mongoose', () => {
 			const other = dbs.other as Connection;
 			other.name.should.eql(otherDatabaseName);
 			other.readyState.should.eql(1);
+		});
+
+		it('models registered to admin db should not be available on other db', async () => {
+			const dbs = await mongooseLib.connect();
+			dbs.should.have.property('admin');
+			dbs.should.have.property('other');
+
+			intersection(
+				dbs.admin.modelNames(),
+				dbs.other.modelNames()
+			).length.should.eql(0);
 		});
 	});
 });

--- a/src/lib/passport.ts
+++ b/src/lib/passport.ts
@@ -2,10 +2,8 @@ import path from 'path';
 
 import passport from 'passport';
 
-import { UserModel } from '../app/core/user/user.model';
-import { dbs, config } from '../dependencies';
-
-const User = dbs.admin.model('User') as UserModel;
+import { User } from '../app/core/user/user.model';
+import { config } from '../dependencies';
 
 export const init = async () => {
 	// Serialize sessions

--- a/src/lib/strategies/local.ts
+++ b/src/lib/strategies/local.ts
@@ -1,9 +1,6 @@
 import { Strategy as LocalStrategy } from 'passport-local';
 
-import { UserModel } from '../../app/core/user/user.model';
-import { dbs } from '../../dependencies';
-
-const User = dbs.admin.model('User') as UserModel;
+import { User } from '../../app/core/user/user.model';
 
 const verify = (username: string, password: string, done) => {
 	if (!username) {


### PR DESCRIPTION
Currently mongoose models are accessed via db connection and require a typecast.
```
import { UserModel } from './user.model';

const User = dbs.admin.model('User') as UserModel;
```

Since model registry is tied to the db connection, there is no need to access it in this way.  We can just import the model (w/ proper typing) directly since it is already being exported.

```
import { User } from './user.model';
```

For use cases where multiple db connections are used.  Models should explicitly be registered on the appropriate connection.
```
// Register model on default/admin db connection
export const MyModel = model('MyModel', MyModelSchema);

// Register model on secondary db connection
export const OtherModel = dbs.other.model('OtherModel', OtherModelSchema);
```