### PR TITLE
feat: Improve error handling in mongoose init on startup

### DIFF
--- a/config/env/default.js
+++ b/config/env/default.js
@@ -146,6 +146,7 @@ module.exports = {
 	db: {
 		admin: 'mongodb://localhost/node-rest-starter-dev'
 	},
+	mongooseFailOnIndexOptionsConflict: true,
 
 	/**
 	 * Environment Settings

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,4 +10,6 @@ startupFn()
 	})
 	.catch((error) => {
 		logger.fatal(error, 'Startup initialization failed.');
+		// non-zero exit code to let the process know that we've failed
+		process.exit(1);
 	});


### PR DESCRIPTION
* Throw error for missing `admin` db configuration.
* Improve error logging for failed model initialization.
* Add option to not fail on `IndexOptionsConflict` errors.
* Exit process on startup errors.