### PR TITLE
fix: Remove db connections on disconnect

### DIFF
--- a/src/lib/mongoose.ts
+++ b/src/lib/mongoose.ts
@@ -130,17 +130,19 @@ export const connect = async () => {
 };
 
 //Disconnect from Mongoose
-export const disconnect = () => {
+export const disconnect = async () => {
 	// Create defers for mongoose connections
-	const promises = _.values(dbs).map((d) => {
-		if (isMongoose(d) && d.disconnect) {
-			return d.disconnect().catch(() => Promise.resolve());
-		}
-		return Promise.resolve();
-	});
+	const promises = Object.values(dbs)
+		.filter(isMongoose)
+		.map((d) => d.disconnect().catch(() => Promise.resolve()));
 
 	// Wait for all to finish, successful or not
-	return Promise.all(promises);
+	await Promise.all(promises);
+
+	// Remove connections
+	for (const key of Object.keys(dbs)) {
+		delete dbs[key];
+	}
 };
 
 async function initializeModel(name: string, model: Model<unknown>) {

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-console */
 import Mocha, { MochaOptions } from 'mocha';
+import 'should';
 import { hideBin } from 'yargs/helpers';
 import yargs from 'yargs/yargs';
 
@@ -29,7 +30,7 @@ mongoose
 		console.info('Mongoose connected, proceeding with tests');
 
 		process.on('exit', () => {
-			mongoose.disconnect();
+			mongoose.disconnect().then();
 		});
 
 		// Create the mocha instance


### PR DESCRIPTION
db connections stored in `dbs` were not being removed on disconnect.  This was causing issues in unit tests for downstream projects.