### PR TITLE
feat: Integrate migrate-mongo library for automatic db migrations

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -13,6 +13,9 @@
 	"plugins": ["deprecation", "jsdoc", "prettier"],
 
 	"extends": ["eslint:recommended"],
+
+	"ignorePatterns": ["src/migrations/sample-migration.ts"],
+
 	"rules": {
 		"arrow-parens": ["error", "always"],
 		"eqeqeq": ["error", "smart"],

--- a/config/default.js
+++ b/config/default.js
@@ -217,6 +217,26 @@ module.exports = {
 	},
 	mongooseFailOnIndexOptionsConflict: true,
 
+	migrateMongo: {
+		enabled: true,
+
+		// The migrations dir, can be an relative or absolute path. Only edit this when really necessary.
+		migrationsDir: 'src/migrations',
+
+		// The mongodb collection where the applied changes are stored. Only edit this when really necessary.
+		changelogCollectionName: 'changelog',
+
+		// The file extension to create migrations and search for in migration dir
+		migrationFileExtension: '.js',
+
+		// Enable the algorithm to create a checksum of the file contents and use that in the comparison to determine
+		// if the file should be run.  Requires that scripts are coded to be run multiple times.
+		useFileHash: false,
+
+		// Don't change this, unless you know what you're doing
+		moduleSystem: 'commonjs'
+	},
+
 	/*
 	 * The maximum time in milliseconds allowed for processing operation on the cursor by a mongo query
 	 */

--- a/config/development.template.js
+++ b/config/development.template.js
@@ -23,6 +23,11 @@ module.exports = {
 	},
 	mongooseFailOnIndexOptionsConflict: false,
 
+	migrateMongo: {
+		enabled: false,
+		migrationFileExtension: '.ts'
+	},
+
 	/**
 	 * Environment Settings
 	 */

--- a/migrate-mongo-config.js
+++ b/migrate-mongo-config.js
@@ -1,0 +1,36 @@
+// In this file you can configure migrate-mongo
+
+const config = {
+	mongodb: {
+		// TODO Change (or review) the url to your MongoDB:
+		url: 'mongodb://localhost:27017',
+
+		// TODO Change this to your database name:
+		databaseName: 'YOURDATABASENAME',
+
+		options: {
+			useNewUrlParser: true, // removes a deprecation warning when connecting
+			useUnifiedTopology: true // removes a deprecating warning when connecting
+			//   connectTimeoutMS: 3600000, // increase connection timeout to 1 hour
+			//   socketTimeoutMS: 3600000, // increase socket timeout to 1 hour
+		}
+	},
+
+	// The migrations dir, can be an relative or absolute path. Only edit this when really necessary.
+	migrationsDir: 'src/migrations',
+
+	// The mongodb collection where the applied changes are stored. Only edit this when really necessary.
+	changelogCollectionName: 'changelog',
+
+	// The file extension to create migrations and search for in migration dir
+	migrationFileExtension: '.ts',
+
+	// Enable the algorithm to create a checksum of the file contents and use that in the comparison to determine
+	// if the file should be run.  Requires that scripts are coded to be run multiple times.
+	useFileHash: false,
+
+	// Don't change this, unless you know what you're doing
+	moduleSystem: 'commonjs'
+};
+
+module.exports = config;

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@types/config": "^3.3.4",
+        "@types/migrate-mongo": "^10.0.4",
         "agenda": "^4.3.0",
         "async": "2.6",
         "chalk": "2",
@@ -33,6 +34,7 @@
         "lodash": "4.17.21",
         "luxon": "^1.28.1",
         "method-override": "3.0",
+        "migrate-mongo": "^11.0.0",
         "mongoose": "^6.12.6",
         "mongoose-unique-validator": "3.1.0",
         "morgan": "1.9",
@@ -1095,6 +1097,17 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
+      "integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
+      "dependencies": {
+        "regenerator-runtime": "^0.14.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.23.9",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.23.9.tgz",
@@ -1527,10 +1540,9 @@
       }
     },
     "node_modules/@mongodb-js/saslprep": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.4.tgz",
-      "integrity": "sha512-8zJ8N1x51xo9hwPh6AWnKdLGEC5N3lDa6kms1YHmFBoRhTpJR6HG8wWk0td1MVCu9cD4YBrvjZEtd5Obw0Fbnw==",
-      "optional": true,
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.5.tgz",
+      "integrity": "sha512-XLNOMH66KhJzUJNwT/qlMnS4WsNDWD5ASdyaSH3EtK+F4r/CFGa3jT4GNi4mfOitGvWXtdLgQJkQjxSVrio+jA==",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -2702,6 +2714,108 @@
       "version": "1.27.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/migrate-mongo": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/@types/migrate-mongo/-/migrate-mongo-10.0.4.tgz",
+      "integrity": "sha512-+9JAzkIbxgox33wCT18bdpZ6ASYo1qwbf4Gg8kTbqvT48ajosSbZBGg94Vsy3baFzT6+DUXWylY/DcoOWOPNRg==",
+      "dependencies": {
+        "@types/node": "*",
+        "mongodb": "^6.1.0"
+      }
+    },
+    "node_modules/@types/migrate-mongo/node_modules/@types/whatwg-url": {
+      "version": "11.0.4",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.4.tgz",
+      "integrity": "sha512-lXCmTWSHJvf0TRSO58nm978b8HJ/EdsSsEKLd3ODHFjo+3VGAyyTp4v50nWvwtzBxSMQrVOK7tcuN0zGPLICMw==",
+      "dependencies": {
+        "@types/webidl-conversions": "*"
+      }
+    },
+    "node_modules/@types/migrate-mongo/node_modules/bson": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-6.6.0.tgz",
+      "integrity": "sha512-BVINv2SgcMjL4oYbBuCQTpE3/VKOSxrOA8Cj/wQP7izSzlBGVomdm+TcUd0Pzy0ytLSSDweCKQ6X3f5veM5LQA==",
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "node_modules/@types/migrate-mongo/node_modules/mongodb": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.5.0.tgz",
+      "integrity": "sha512-Fozq68InT+JKABGLqctgtb8P56pRrJFkbhW0ux+x1mdHeyinor8oNzJqwLjV/t5X5nJGfTlluxfyMnOXNggIUA==",
+      "dependencies": {
+        "@mongodb-js/saslprep": "^1.1.5",
+        "bson": "^6.4.0",
+        "mongodb-connection-string-url": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.188.0",
+        "@mongodb-js/zstd": "^1.1.0",
+        "gcp-metadata": "^5.2.0",
+        "kerberos": "^2.0.1",
+        "mongodb-client-encryption": ">=6.0.0 <7",
+        "snappy": "^7.2.2",
+        "socks": "^2.7.1"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "@mongodb-js/zstd": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        },
+        "kerberos": {
+          "optional": true
+        },
+        "mongodb-client-encryption": {
+          "optional": true
+        },
+        "snappy": {
+          "optional": true
+        },
+        "socks": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/migrate-mongo/node_modules/mongodb-connection-string-url": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.0.tgz",
+      "integrity": "sha512-t1Vf+m1I5hC2M5RJx/7AtxgABy1cZmIPQRMXw+gEIPn/cZNF3Oiy+l0UIypUwVB5trcWHq3crg2g3uAR9aAwsQ==",
+      "dependencies": {
+        "@types/whatwg-url": "^11.0.2",
+        "whatwg-url": "^13.0.0"
+      }
+    },
+    "node_modules/@types/migrate-mongo/node_modules/tr46": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+      "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+      "dependencies": {
+        "punycode": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/migrate-mongo/node_modules/whatwg-url": {
+      "version": "13.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
+      "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
+      "dependencies": {
+        "tr46": "^4.1.1",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/@types/mime": {
       "version": "3.0.1",
@@ -4006,6 +4120,29 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-table3": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.4.tgz",
+      "integrity": "sha512-Lm3L0p+/npIQWNIiyF/nAn7T5dnOwR3xNTHXYEBFBFVPXzCVNZ5lqEC/1eo/EVfpDsQ1I+TX4ORPQgp+UI0CRw==",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/cli-table3/node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/cli-truncate": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
@@ -4420,6 +4557,21 @@
     "node_modules/dasherize": {
       "version": "2.0.0",
       "license": "MIT"
+    },
+    "node_modules/date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=0.11"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/date-fns"
+      }
     },
     "node_modules/date.js": {
       "version": "0.3.3",
@@ -6123,6 +6275,14 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/fn-args": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fn-args/-/fn-args-5.0.0.tgz",
+      "integrity": "sha512-CtbfI3oFFc3nbdIoHycrfbrxiGgxXBXXuyOl49h47JawM1mYrqpiRqnH5CB2mBatdXvHHOUO6a+RiAuuvKt0lw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/fn.name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
@@ -6189,6 +6349,19 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "dependencies": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -6492,7 +6665,6 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.10",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/graphemer": {
@@ -7556,6 +7728,17 @@
         "node": ">=6"
       }
     },
+    "node_modules/jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "dependencies": {
+        "universalify": "^2.0.0"
+      },
+      "optionalDependencies": {
+        "graceful-fs": "^4.1.6"
+      }
+    },
     "node_modules/jsonpath": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
@@ -8168,8 +8351,7 @@
     },
     "node_modules/memory-pager": {
       "version": "1.5.0",
-      "license": "MIT",
-      "optional": true
+      "license": "MIT"
     },
     "node_modules/merge-descriptors": {
       "version": "1.0.1",
@@ -8230,6 +8412,37 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/migrate-mongo": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/migrate-mongo/-/migrate-mongo-11.0.0.tgz",
+      "integrity": "sha512-GB/gHzUwp/fL1w6ksNGihTyb+cSrm6NbVLlz1OSkQKaLlzAXMwH7iKK2ZS7W5v+I8vXiY2rL58WTUZSAL6QR+A==",
+      "dependencies": {
+        "cli-table3": "^0.6.1",
+        "commander": "^9.1.0",
+        "date-fns": "^2.28.0",
+        "fn-args": "^5.0.0",
+        "fs-extra": "^10.0.1",
+        "lodash": "^4.17.21",
+        "p-each-series": "^2.2.0"
+      },
+      "bin": {
+        "migrate-mongo": "bin/migrate-mongo.js"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "peerDependencies": {
+        "mongodb": "^4.4.1 || ^5.0.0 || ^6.0.0"
+      }
+    },
+    "node_modules/migrate-mongo/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/mime": {
@@ -9263,6 +9476,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/p-each-series": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+      "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -9683,8 +9907,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "license": "MIT",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
       "engines": {
         "node": ">=6"
       }
@@ -9839,6 +10064,11 @@
       "engines": {
         "node": ">=4.0.0"
       }
+    },
+    "node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.0",
@@ -10698,7 +10928,6 @@
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "memory-pager": "^1.0.2"
       }
@@ -11539,6 +11768,14 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
       "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+    },
+    "node_modules/universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
     },
     "node_modules/unpipe": {
       "version": "1.0.0",
@@ -12915,6 +13152,14 @@
       "integrity": "sha512-9tcKgqKbs3xGJ+NtKF2ndOBBLVwPjl1SHxPQkd36r3Dlirw3xWUeGaTbqr7uGZcTaxkVNwc+03SVP7aCdWrTlA==",
       "dev": true
     },
+    "@babel/runtime": {
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
+      "integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
+      "requires": {
+        "regenerator-runtime": "^0.14.0"
+      }
+    },
     "@babel/template": {
       "version": "7.23.9",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.23.9.tgz",
@@ -13225,10 +13470,9 @@
       }
     },
     "@mongodb-js/saslprep": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.4.tgz",
-      "integrity": "sha512-8zJ8N1x51xo9hwPh6AWnKdLGEC5N3lDa6kms1YHmFBoRhTpJR6HG8wWk0td1MVCu9cD4YBrvjZEtd5Obw0Fbnw==",
-      "optional": true,
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.5.tgz",
+      "integrity": "sha512-XLNOMH66KhJzUJNwT/qlMnS4WsNDWD5ASdyaSH3EtK+F4r/CFGa3jT4GNi4mfOitGvWXtdLgQJkQjxSVrio+jA==",
       "requires": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -14104,6 +14348,66 @@
       "version": "1.27.1",
       "dev": true
     },
+    "@types/migrate-mongo": {
+      "version": "10.0.4",
+      "resolved": "https://registry.npmjs.org/@types/migrate-mongo/-/migrate-mongo-10.0.4.tgz",
+      "integrity": "sha512-+9JAzkIbxgox33wCT18bdpZ6ASYo1qwbf4Gg8kTbqvT48ajosSbZBGg94Vsy3baFzT6+DUXWylY/DcoOWOPNRg==",
+      "requires": {
+        "@types/node": "*",
+        "mongodb": "^6.1.0"
+      },
+      "dependencies": {
+        "@types/whatwg-url": {
+          "version": "11.0.4",
+          "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-11.0.4.tgz",
+          "integrity": "sha512-lXCmTWSHJvf0TRSO58nm978b8HJ/EdsSsEKLd3ODHFjo+3VGAyyTp4v50nWvwtzBxSMQrVOK7tcuN0zGPLICMw==",
+          "requires": {
+            "@types/webidl-conversions": "*"
+          }
+        },
+        "bson": {
+          "version": "6.6.0",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-6.6.0.tgz",
+          "integrity": "sha512-BVINv2SgcMjL4oYbBuCQTpE3/VKOSxrOA8Cj/wQP7izSzlBGVomdm+TcUd0Pzy0ytLSSDweCKQ6X3f5veM5LQA=="
+        },
+        "mongodb": {
+          "version": "6.5.0",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.5.0.tgz",
+          "integrity": "sha512-Fozq68InT+JKABGLqctgtb8P56pRrJFkbhW0ux+x1mdHeyinor8oNzJqwLjV/t5X5nJGfTlluxfyMnOXNggIUA==",
+          "requires": {
+            "@mongodb-js/saslprep": "^1.1.5",
+            "bson": "^6.4.0",
+            "mongodb-connection-string-url": "^3.0.0"
+          }
+        },
+        "mongodb-connection-string-url": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-3.0.0.tgz",
+          "integrity": "sha512-t1Vf+m1I5hC2M5RJx/7AtxgABy1cZmIPQRMXw+gEIPn/cZNF3Oiy+l0UIypUwVB5trcWHq3crg2g3uAR9aAwsQ==",
+          "requires": {
+            "@types/whatwg-url": "^11.0.2",
+            "whatwg-url": "^13.0.0"
+          }
+        },
+        "tr46": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-4.1.1.tgz",
+          "integrity": "sha512-2lv/66T7e5yNyhAAC4NaKe5nVavzuGJQVVtRYLyQ2OI8tsJ61PMLlelehb0wi2Hx6+hT/OJUWZcw8MjlSRnxvw==",
+          "requires": {
+            "punycode": "^2.3.0"
+          }
+        },
+        "whatwg-url": {
+          "version": "13.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-13.0.0.tgz",
+          "integrity": "sha512-9WWbymnqj57+XEuqADHrCJ2eSXzn8WXIW/YSGaZtb2WKAInQ6CHfaUUcTyyver0p8BDg5StLQq8h1vtZuwmOig==",
+          "requires": {
+            "tr46": "^4.1.1",
+            "webidl-conversions": "^7.0.0"
+          }
+        }
+      }
+    },
     "@types/mime": {
       "version": "3.0.1"
     },
@@ -14966,6 +15270,23 @@
         "restore-cursor": "^4.0.0"
       }
     },
+    "cli-table3": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.4.tgz",
+      "integrity": "sha512-Lm3L0p+/npIQWNIiyF/nAn7T5dnOwR3xNTHXYEBFBFVPXzCVNZ5lqEC/1eo/EVfpDsQ1I+TX4ORPQgp+UI0CRw==",
+      "requires": {
+        "@colors/colors": "1.5.0",
+        "string-width": "^4.2.0"
+      },
+      "dependencies": {
+        "@colors/colors": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+          "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+          "optional": true
+        }
+      }
+    },
     "cli-truncate": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
@@ -15241,6 +15562,14 @@
     },
     "dasherize": {
       "version": "2.0.0"
+    },
+    "date-fns": {
+      "version": "2.30.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.30.0.tgz",
+      "integrity": "sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==",
+      "requires": {
+        "@babel/runtime": "^7.21.0"
+      }
     },
     "date.js": {
       "version": "0.3.3",
@@ -16428,6 +16757,11 @@
       "version": "3.2.7",
       "dev": true
     },
+    "fn-args": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/fn-args/-/fn-args-5.0.0.tgz",
+      "integrity": "sha512-CtbfI3oFFc3nbdIoHycrfbrxiGgxXBXXuyOl49h47JawM1mYrqpiRqnH5CB2mBatdXvHHOUO6a+RiAuuvKt0lw=="
+    },
     "fn.name": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
@@ -16464,6 +16798,16 @@
     "fromentries": {
       "version": "1.3.2",
       "dev": true
+    },
+    "fs-extra": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
+      "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
+      "requires": {
+        "graceful-fs": "^4.2.0",
+        "jsonfile": "^6.0.1",
+        "universalify": "^2.0.0"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0"
@@ -16658,8 +17002,7 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.10",
-      "dev": true
+      "version": "4.2.10"
     },
     "graphemer": {
       "version": "1.4.0",
@@ -17335,6 +17678,15 @@
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
       "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
+    "jsonfile": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+      "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+      "requires": {
+        "graceful-fs": "^4.1.6",
+        "universalify": "^2.0.0"
+      }
+    },
     "jsonpath": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/jsonpath/-/jsonpath-1.1.1.tgz",
@@ -17742,8 +18094,7 @@
       "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="
     },
     "memory-pager": {
-      "version": "1.5.0",
-      "optional": true
+      "version": "1.5.0"
     },
     "merge-descriptors": {
       "version": "1.0.1"
@@ -17787,6 +18138,27 @@
       "requires": {
         "braces": "^3.0.2",
         "picomatch": "^2.3.1"
+      }
+    },
+    "migrate-mongo": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/migrate-mongo/-/migrate-mongo-11.0.0.tgz",
+      "integrity": "sha512-GB/gHzUwp/fL1w6ksNGihTyb+cSrm6NbVLlz1OSkQKaLlzAXMwH7iKK2ZS7W5v+I8vXiY2rL58WTUZSAL6QR+A==",
+      "requires": {
+        "cli-table3": "^0.6.1",
+        "commander": "^9.1.0",
+        "date-fns": "^2.28.0",
+        "fn-args": "^5.0.0",
+        "fs-extra": "^10.0.1",
+        "lodash": "^4.17.21",
+        "p-each-series": "^2.2.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "9.5.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+          "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ=="
+        }
       }
     },
     "mime": {
@@ -18489,6 +18861,11 @@
       "integrity": "sha512-BZOr3nRQHOntUjTrH8+Lh54smKHoHyur8We1V8DSMVrl5A2malOOwuJRnKRDjSnkoeBh4at6BwEnb5I7Jl31wg==",
       "dev": true
     },
+    "p-each-series": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/p-each-series/-/p-each-series-2.2.0.tgz",
+      "integrity": "sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA=="
+    },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
@@ -18747,7 +19124,9 @@
       }
     },
     "punycode": {
-      "version": "2.1.1"
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="
     },
     "qs": {
       "version": "6.11.0",
@@ -18843,6 +19222,11 @@
     },
     "referrer-policy": {
       "version": "1.2.0"
+    },
+    "regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "regexp.prototype.flags": {
       "version": "1.5.0",
@@ -19459,7 +19843,6 @@
     },
     "sparse-bitfield": {
       "version": "3.0.3",
-      "optional": true,
       "requires": {
         "memory-pager": "^1.0.2"
       }
@@ -20043,6 +20426,11 @@
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.12.1.tgz",
       "integrity": "sha512-hEQt0+ZLDVUMhebKxL4x1BTtDY7bavVofhZ9KZ4aI26X9SRaE+Y3m83XUL1UP2jn8ynjndwCCpEHdUG+9pP1Tw=="
+    },
+    "universalify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+      "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw=="
     },
     "unpipe": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     ]
   },
   "dependencies": {
-    "@types/config": "^3.3.4",
     "agenda": "^4.3.0",
     "async": "2.6",
     "chalk": "2",
@@ -74,6 +73,7 @@
     "lodash": "4.17.21",
     "luxon": "^1.28.1",
     "method-override": "3.0",
+    "migrate-mongo": "^11.0.0",
     "mongoose": "^6.12.6",
     "mongoose-unique-validator": "3.1.0",
     "morgan": "1.9",
@@ -100,10 +100,12 @@
     "@swc/cli": "^0.1.62",
     "@swc/core": "^1.3.73",
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
+    "@types/config": "^3.3.4",
     "@types/express": "4.16",
     "@types/jsonpath": "^0.2.0",
     "@types/lodash": "^4.14.176",
     "@types/luxon": "^1.27.1",
+    "@types/migrate-mongo": "^10.0.4",
     "@types/mocha": "^8.2.1",
     "@types/passport": "1.0.10",
     "@types/q": "1.5",

--- a/src/app/core/user/auth/user-authorization.service.spec.ts
+++ b/src/app/core/user/auth/user-authorization.service.spec.ts
@@ -5,7 +5,6 @@ import { createSandbox } from 'sinon';
 import userAuthorizationService from './user-authorization.service';
 import { config } from '../../../../dependencies';
 import { IUser, User } from '../user.model';
-import userService from '../user.service';
 
 function userSpec(key) {
 	return {

--- a/src/app/core/user/user.controller.spec.ts
+++ b/src/app/core/user/user.controller.spec.ts
@@ -2,7 +2,7 @@ import { assert, createSandbox } from 'sinon';
 
 import userAuthorizationService from './auth/user-authorization.service';
 import * as userController from './user.controller';
-import { User, UserDocument } from './user.model';
+import { User } from './user.model';
 import userService from './user.service';
 import { auditService, config } from '../../../dependencies';
 import { getResponseSpy } from '../../../spec/helpers';

--- a/src/lib/migrate-mongo.ts
+++ b/src/lib/migrate-mongo.ts
@@ -1,0 +1,19 @@
+import config from 'config';
+import * as migrateMongo from 'migrate-mongo';
+import { Mongoose } from 'mongoose';
+
+import { logger } from './logger';
+
+export const migrate = async (db: Mongoose) => {
+	if (config.get<boolean>('migrateMongo.enabled')) {
+		logger.info('MigrateMongo: migration enabled');
+		migrateMongo.config.set(config.get('migrateMongo'));
+
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		const migrated = await migrateMongo.up(db.connection.db);
+		logger.info(`MigrateMongo: executed ${migrated.length} migration(s)`);
+	} else {
+		logger.info('MigrateMongo: migration disabled');
+	}
+};

--- a/src/lib/mongoose.ts
+++ b/src/lib/mongoose.ts
@@ -68,6 +68,7 @@ export const connect = async () => {
 
 	logger.info(`Mongoose: Setting debug to ${mongooseDebug}`);
 	mongoose.set('debug', mongooseDebug);
+	mongoose.set('strictQuery', true);
 
 	const dbSpecs: Array<MongooseDbSpec> = [];
 	let defaultDbSpec: MongooseDbSpec;

--- a/src/migrations/sample-migration.ts
+++ b/src/migrations/sample-migration.ts
@@ -1,0 +1,20 @@
+import * as mongo from 'mongodb';
+
+import { logger } from '../lib/logger';
+
+export const up = async (db: mongo.Db): Promise<void> => {
+	logger.debug('MigrateMongo: Executing migration...');
+
+	// TODO write your migration here.
+	// See https://github.com/seppevs/migrate-mongo/#creating-a-new-migration-script
+	// Example:
+	// await db.collection('albums').updateOne({artist: 'The Beatles'}, {$set: {blacklisted: true}});
+};
+
+export const down = async (db: mongo.Db): Promise<void> => {
+	logger.debug('MigrateMongo: Rolling back migration...');
+
+	// TODO write the statements to rollback your migration (if possible)
+	// Example:
+	// await db.collection('albums').updateOne({artist: 'The Beatles'}, {$set: {blacklisted: false}});
+};

--- a/src/rollback-migrations.ts
+++ b/src/rollback-migrations.ts
@@ -1,0 +1,70 @@
+/* eslint-disable no-console */
+
+import config from 'config';
+import { DateTime } from 'luxon';
+import * as migrateMongo from 'migrate-mongo';
+
+import { logger } from './lib/logger';
+import * as mongoose from './lib/mongoose';
+
+const rollbackMigrations = async () => {
+	logger.silent = process.argv?.[3] !== '--logger';
+	logger.info('Started migration rollback...');
+
+	const db = await mongoose.connect();
+
+	migrateMongo.config.set(config.get('migrateMongo'));
+
+	try {
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		const migrations = await migrateMongo.status(db.admin.connection.db);
+
+		if (process.argv.length < 3) {
+			const migrationDates = [
+				...new Set(
+					migrations
+						.map((migration) => migration.appliedAt)
+						.filter((appliedAt) => appliedAt !== 'PENDING')
+						.map((appliedAt) => DateTime.fromISO(appliedAt).toISODate())
+				)
+			];
+			if (migrationDates.length > 0) {
+				console.log('Past migration dates:');
+				migrationDates.forEach((appliedAt) => {
+					console.log(appliedAt);
+				});
+			} else {
+				console.log('No migrations found.');
+			}
+			return;
+		}
+
+		const date = DateTime.fromISO(process.argv[2]).toISO();
+
+		let migration = migrations.pop();
+		while (migration.appliedAt !== 'PENDING' && migration.appliedAt > date) {
+			console.log(`rolling back ${migration.fileName}`);
+
+			// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+			// @ts-ignore
+			// eslint-disable-next-line no-await-in-loop
+			await migrateMongo.down(db.admin.connection.db);
+
+			migration = migrations.pop();
+		}
+	} catch (err) {
+		logger.error('Execution failed.');
+		return Promise.reject(err);
+	}
+};
+
+rollbackMigrations()
+	.then(() => {
+		logger.info('Execution complete');
+		process.exit(0);
+	})
+	.catch((error) => {
+		logger.error('Startup initialization failed.', error);
+		process.exit(1);
+	});

--- a/src/startup.ts
+++ b/src/startup.ts
@@ -5,6 +5,7 @@ import { Mongoose } from 'mongoose';
 import * as agenda from './lib/agenda';
 import * as express from './lib/express';
 import { logger } from './lib/logger';
+import * as migrate_mongo from './lib/migrate-mongo';
 import * as mongoose from './lib/mongoose';
 import socketio from './lib/socket.io';
 
@@ -13,6 +14,9 @@ export default async function () {
 
 	// Init mongoose connection(s)
 	const db = await mongoose.connect();
+
+	// Run any required mongo migrations
+	await migrate_mongo.migrate(db.admin as Mongoose);
 
 	// Init agenda.ts scheduler
 	await agenda.init();


### PR DESCRIPTION
* On application start, uses migrate-mongo to check for and execute any pending db migrations.
* Added `rollback-migrations` utility script to simplify rolling back db migrations.