### PR TITLE
fix: fix lint-staged config

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,6 +135,6 @@
     "swagger-parser": "^10.0.3"
   },
   "lint-staged": {
-    "*.{js, ts}": "eslint --fix"
+    "*.{js,ts}": "eslint --fix"
   }
 }


### PR DESCRIPTION
Whitespace in config was causing ts files to not be linted on commit.